### PR TITLE
find the correct boost-python library for python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ if osplatform in ["linux", "linux2"]:
 # try to find the boost library matching the python version
 suffixes = [ # Debian naming convention for version installed in parallel
              "-py%d%d" % (pyversion.major, pyversion.minor),
+             # standard suffix for Python3
+             "%d" % (pyversion.major),
              # standard naming
              "",
              # former naming schema?


### PR DESCRIPTION
With python2.x and python3.x installed, the default naming for libboost_python is:
libboost_python.a and libboost_python-mt.a for python2.x
libboost_python3.a and libboost_python3-mt.a for python3.x 

When installing this module with python3, the python2 library was linked, which resulted in an ImportError at runtime.