### PR TITLE
Add to_python converter for C++ type: std::pair<unsigned int, unsigned int>

### DIFF
--- a/lib/osm.cc
+++ b/lib/osm.cc
@@ -50,6 +50,7 @@ BOOST_PYTHON_MODULE(_osm)
 
     to_python_converter<osmium::Timestamp, Timestamp_to_python>();
     std_pair_to_python_converter<int, int>();
+    std_pair_to_python_converter<unsigned int, unsigned int>();
     std_pair_to_python_converter<unsigned long, unsigned long>();
 
     enum_<osmium::osm_entity_bits::type>("osm_entity_bits")


### PR DESCRIPTION
As requested in #13.