### PR TITLE
Update expected output for test_location_tuple. (Fixes: #15)

### DIFF
--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -108,7 +108,7 @@ class TestWriteTags(unittest.TestCase):
 class TestWriteNode(unittest.TestCase):
 
     def test_location_tuple(self):
-        with WriteExpect('n0 v0 dV c0 t i0 u T x1.0000000 y2.0000000') as w:
+        with WriteExpect('n0 v0 dV c0 t i0 u T x1 y2') as w:
             w.add_node(O(location=(1, 2)))
 
     def test_location_none(self):


### PR DESCRIPTION
This change fixes the test failure with Python 2.7.9 on jessie and Python 2.7.12 on unstable.