### PR TITLE
Documents the need for the geom module to have valid Locations in the WayNodeList

### DIFF
--- a/doc/ref_geom.rst
+++ b/doc/ref_geom.rst
@@ -2,6 +2,7 @@
 ------------------------------------
 
 This module provides various helper functions for geometry handling.
+Note: remember to apply a location handler before in order to use these geometry utilities on node locations.
 
 Geometry Factories
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Without a location cache
```python
def way(_, w):
    km += osmium.geom.haversine_distance(w.nodes)
```
will result in
```
osmium._osmium.InvalidLocationError: Invalid location
```

let's document this since I've seen people running into it.