### PR TITLE
Documentation Fixes

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -37,7 +37,7 @@ input file::
 A handler first of all needs to inherit from one of the handler classes.
 At the moment this is always :py:class:`osmium.SimpleHandler`. Then it
 needs to implement functions for each object type it wants to process. In
-out case it is exactly one function `node()`. All other potential callbacks
+our case it is exactly one function `node()`. All other potential callbacks
 can be safely ignored.
 
 Now the handler needs to be applied to an OSM file. The easiest way to
@@ -102,8 +102,8 @@ Handling Geometries
 Because of the way that OSM data is structured, osmium needs to internally
 cache node geometries, when the handler wants to process the geometries of
 ways and areas. The :py:meth:`~!osmium.SimpleHandler.apply_file` method cannot
-deduct by itself, if this cache is needed. Therefore locations need to be
-explicitly enabled by setting the location parameter to true::
+deduce by itself if this cache is needed. Therefore locations need to be
+explicitly enabled by setting the locations parameter to True::
 
     h.apply_file("test.osm.pbf", locations=True, idx='sparse_mem_array')
 
@@ -124,7 +124,7 @@ Interfacing with Shapely
 
 Pyosmium is a library for processing OSM files and therefore offers almost
 no functionality for processing geometries further. There are other libraries
-for that puspose. To interface with these libraries you can simply convert the
+for that purpose. To interface with these libraries you can simply convert the
 osmium geometries into WKB or WKT format and import the result. The following
 example uses the libgeos wrapper `Shapely`_ to compute the total way length::
 
@@ -168,7 +168,7 @@ opens a new writer for a packed OSM XML file. Objects can be written
 by using one of the writers ``add_*`` functions.
 
 A simple handler, that only writes out all the nodes from the input
-file into out new ``nodes.osm.bz2`` file would look like this::
+file into our new ``nodes.osm.bz2`` file would look like this::
 
     import osmium
 
@@ -183,15 +183,15 @@ file into out new ``nodes.osm.bz2`` file would look like this::
 This example shows that an unmodified object can be written out directly
 to the writer. Normally, however, you want to modify some data. The native
 osmium OSM types are immutable and cannot be changed directly. Therefore
-you have create a copy that can be changed. The ``node``, ``way`` and ``relation``
+you have to create a copy that can be changed. The ``node``, ``way`` and ``relation``
 objects offer a convenient ``replace()`` function to achieve exactly that.
-The function makes a copy and a the same time replaces all attibutes where
+The function makes a copy and at the same time replaces all attributes where
 new values are given as parameters to the function.
 
 Let's say you want to
 remove all the user names from your nodes before saving them to the new
 file (maybe to save some space), then the ``node()`` handler callback above
-needs to be changed like that::
+needs to be changed like this::
 
     class NodeWriter(osmium.SimpleHandler):
         ...

--- a/doc/ref_index.rst
+++ b/doc/ref_index.rst
@@ -12,7 +12,7 @@ Node location can be cached in a ``LocationTable``. There are different
 implementations available which should be choosen according to the size of
 data and whether or not the cache should be permanent. See the Osmium manual
 for a detailed explaination. The compiled in types can be listed with the
-``map_types`` function, new storages can be created with ``create_map``.
+``map_types`` function, new stores can be created with ``create_map``.
 
 .. autofunction:: osmium.index.map_types
 

--- a/doc/ref_osm.rst
+++ b/doc/ref_osm.rst
@@ -1,14 +1,14 @@
 ``osm`` - Basic Datatypes
 -------------------------
 
-The ``osm`` submodule contains definition of the basic data types used
+The ``osm`` submodule contains definitions of the basic data types used
 throughout the library.
 
 Native OSM Objects
 ^^^^^^^^^^^^^^^^^^
 
 Native OSM object classes are lightwight wrappers around the osmium OSM
-data classes. They are immutable and generally bound to the life-time of
+data classes. They are immutable and generally bound to the lifetime of
 the buffer they are saved in.
 
 There are five classes representing the basic OSM entities.

--- a/doc/ref_osmium.rst
+++ b/doc/ref_osmium.rst
@@ -12,7 +12,7 @@ functions and processors are exported as well in this module.
 Input Handlers
 ^^^^^^^^^^^^^^
 
-An input handler implements provides the base class for writing custom
+An input handler provides the base class for writing custom
 data processors. They take input data, usually from a file, and forward
 it to handler functions.
 
@@ -28,7 +28,7 @@ handle native ``osmium.osm`` objects as well as any Python object that
 exposes the same attributes. It is not necessary to implement the full
 list of attributes as any missing attributes will be replaced with a
 sensible default value when writing. See :ref:`mutable-objects`
-for a detailed discussion what data formats are understood for each attribute.
+for a detailed discussion of the data formats understood for each attribute.
 
 .. warning::
 

--- a/lib/index.cc
+++ b/lib/index.cc
@@ -43,7 +43,7 @@ BOOST_PYTHON_MODULE(index)
         (arg("map_type")),
         "Create a new location store. The string parameter takes the type "
         "and, where required, additional arguments separated by comma. For "
-        "example, to create a array cache backed by a file ``foo.store``, "
+        "example, to create an array cache backed by a file ``foo.store``, "
         "the map_type should be ``dense_file_array,foo.store``.");
     def("map_types", &map_types,
         "Return a list of strings with valid types for the location table.");

--- a/lib/osm.cc
+++ b/lib/osm.cc
@@ -65,7 +65,7 @@ BOOST_PYTHON_MODULE(_osm)
     ;
     class_<osmium::Location>("Location",
         "A geographic coordinate in WGS84 projection. A location doesn't "
-         "have to be necessarily valid.")
+         "necessarily have to be valid.")
         .def(init<double, double>())
         .add_property("x", &osmium::Location::x,
                       "(read-only) X coordinate (longitude) as a fixed-point integer.")
@@ -229,7 +229,7 @@ BOOST_PYTHON_MODULE(_osm)
              "Get the absolute value of the id of this object.")
         .def("user_is_anonymous", &osmium::OSMObject::user_is_anonymous,
              arg("self"),
-             "Check if the user anonymous. If true, the uid does not uniquely "
+             "Check if the user is anonymous. If true, the uid does not uniquely "
              "identify a single user but only the group of all anonymous users "
              "in general.")
     ;
@@ -310,7 +310,7 @@ BOOST_PYTHON_MODULE(_osm)
                       "(read-only) Timestamp when the changeset was first opened.")
         .add_property("closed_at", &osmium::Changeset::closed_at,
                       "(read-only) Timestamp when the changeset was finalized. May be "
-                      "None when the changeset is still open/")
+                      "None when the changeset is still open.")
         .add_property("open", &osmium::Changeset::open,
                       "(read-only) True when the changeset is still open.")
         .add_property("num_changes", &osmium::Changeset::num_changes,

--- a/lib/osm.cc
+++ b/lib/osm.cc
@@ -81,7 +81,7 @@ BOOST_PYTHON_MODULE(_osm)
     ;
     class_<osmium::Box>("Box",
         "A bounding box around a geographic area. Such a box consists of two "
-        ":py:class:`osmium.osm.Location`s. Those locations may be invalid in "
+        ":py:class:`osmium.osm.Location`'s. Those locations may be invalid in "
         "which case the box is considered invalid, too.")
         .def(init<double, double, double, double>())
         .def(init<osmium::Location, osmium::Location>())

--- a/lib/osmium.cc
+++ b/lib/osmium.cc
@@ -97,7 +97,7 @@ BOOST_PYTHON_MODULE(_osmium)
              "positions. In that case, the type of this position index can be\n"
              "further selected in idx. If an area callback is implemented, then\n"
              "the file will be scanned twice and a location handler and a\n"
-             "handler for assembling multipolygones and areas from ways will\n"
+             "handler for assembling multipolygons and areas from ways will\n"
              "be executed.")
         .def("apply_buffer", &SimpleHandlerWrap::apply_buffer,
               (arg("self"), arg("buffer"), arg("format"),


### PR DESCRIPTION
Fix assorted typos and the link from osm.Box to osm.Location:
```
class osmium.osm.Box

    A bounding box around a geographic area. Such a box consists of two :py:class:`osmium.osm.Location`s. Those locations may be invalid in which case the box is considered invalid, too.
```
http://docs.osmcode.org/pyosmium/latest/ref_osm.html#other-osm-entity-attributes
