### PR TITLE
support finding Boost Python libraries on Gentoo Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ elif osplatform in ["linux", "linux2"]:
 # try to find the boost library matching the python version
 suffixes = [ # Debian naming convention for version installed in parallel
              "-py%d%d" % (pyversion.major, pyversion.minor),
+             # Gentoo naming convention for version installed in parallel
+             "-%d.%d" % (pyversion.major, pyversion.minor),
              # standard suffix for Python3
              "%d" % (pyversion.major),
              # standard naming


### PR DESCRIPTION
Gentoo installs Boost Python libraries (symlinks) as e.g.: ```/usr/lib64/libboost_python-3.5.so```
Please consider supporting this.