### PR TITLE
Appveyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,51 @@
+environment:
+  PYTHON: "C:\\Python36-x64"
+  PYTHON_VERSION: "3.6.x" # currently 3.6.0
+  PYTHON_ARCH: "64"
+
+# branches to build
+branches:
+  # whitelist
+  only:
+    - master
+
+# Operating system (build VM template)
+os: Visual Studio 2015
+
+install:
+  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+  - python --version
+  - cd c:\dev 
+  - git clone --depth 10 https://github.com/osmcode/libosmium.git
+  - dir c:\dev
+  - IF NOT EXIST pyosmium_libs_Release.7z ECHO downloading dependencies pack... && powershell Invoke-WebRequest https://github.com/alex85k/pyosmium_libs/releases/download/0.1/pyosmium_libs_Release.7z -OutFile pyosmium_libs_Release.7z
+  - cd c:\
+  - 7z x c:\dev\pyosmium_libs_Release.7z
+  - dir c:\libs\include
+  - dir c:\libs\lib
+
+# scripts that are called at very beginning, before repo cloning
+init:
+  - git config --global core.autocrlf input
+
+# clone directory
+clone_folder: c:\dev\pyosmium
+
+platform: x64
+configuration: Release
+
+build_script:
+  - cd c:\dev\pyosmium
+  - SET LIBS_PREFIX=c:/libs
+  - SET BOOST_PREFIX=c:/libs
+  - python setup.py build
+  - python setup.py install --user
+
+test_script:
+  - set PATH=%BOOST_PREFIX:/=\%\lib;%PATH%
+  - cd test
+  - python run_tests.py
+  
+#artifacts:
+#  - path: pyosmium_libs_Release.7z
+#    name: pyosmium_libs_Release.7z

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
   - 7z x c:\dev\pyosmium_libs_Release.7z
   - dir c:\libs\include
   - dir c:\libs\lib
+  - pip install nose
 
 # scripts that are called at very beginning, before repo cloning
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
-  PYTHON: "C:\\Python36-x64"
-  PYTHON_VERSION: "3.6.x" # currently 3.6.0
-  PYTHON_ARCH: "64"
 
-# Operating system (build VM template)
+  matrix:
+    #- PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python36-x64"
+
 os: Visual Studio 2015
 
 install:
@@ -17,7 +17,7 @@ install:
   - 7z x c:\dev\pyosmium_libs_Release.7z
   - dir c:\libs\include
   - dir c:\libs\lib
-  - pip install nose
+  - pip install nose wheel
 
 # scripts that are called at very beginning, before repo cloning
 init:
@@ -25,9 +25,6 @@ init:
 
 # clone directory
 clone_folder: c:\dev\pyosmium
-
-platform: x64
-configuration: Release
 
 build_script:
   - cd c:\dev\pyosmium
@@ -40,7 +37,10 @@ test_script:
   - set PATH=%BOOST_PREFIX:/=\%\lib;%PATH%
   - cd test
   - python run_tests.py
-  
-#artifacts:
-#  - path: pyosmium_libs_Release.7z
-#    name: pyosmium_libs_Release.7z
+
+after_test:
+  - cd c:\dev\pyosmium
+  - "%PYTHON%\\python.exe setup.py bdist_wheel"
+
+artifacts:
+  - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,6 @@ environment:
   PYTHON_VERSION: "3.6.x" # currently 3.6.0
   PYTHON_ARCH: "64"
 
-# branches to build
-branches:
-  # whitelist
-  only:
-    - master
-
 # Operating system (build VM template)
 os: Visual Studio 2015
 
@@ -37,8 +31,8 @@ configuration: Release
 
 build_script:
   - cd c:\dev\pyosmium
-  - SET LIBS_PREFIX=c:/libs
   - SET BOOST_PREFIX=c:/libs
+  - SET BOOST_VERSION=1_63
   - python setup.py build
   - python setup.py install --user
 

--- a/lib/index.cc
+++ b/lib/index.cc
@@ -4,6 +4,8 @@
 #include <osmium/index/map/all.hpp>
 #include <osmium/index/node_locations_map.hpp>
 
+#include "win_boost_fix.hpp"
+
 using namespace boost::python;
 
 typedef osmium::index::map::Map<osmium::unsigned_object_id_type, osmium::Location> LocationTable;

--- a/lib/osm.cc
+++ b/lib/osm.cc
@@ -64,6 +64,7 @@ BOOST_PYTHON_MODULE(_osm)
     std_pair_to_python_converter<int, int>();
     std_pair_to_python_converter<unsigned int, unsigned int>();
     std_pair_to_python_converter<unsigned long, unsigned long>();
+    std_pair_to_python_converter<uint64_t, uint64_t>();
 
     enum_<osmium::osm_entity_bits::type>("osm_entity_bits")
         .value("NOTHING", osmium::osm_entity_bits::nothing)

--- a/lib/osmium.cc
+++ b/lib/osmium.cc
@@ -8,6 +8,20 @@
 #include "generic_handler.hpp"
 #include "merged_input.hpp"
 #include "write_handler.hpp"
+#include "win_boost_fix.hpp"
+
+// workarodund for Visual Studio 2015 Update 3
+// https://connect.microsoft.com/VisualStudio/Feedback/Details/2852624
+#if (_MSC_VER > 1800 && _MSC_FULL_VER > 190023918)
+namespace boost {
+    template<>
+    const volatile SimpleHandlerWrap*
+    get_pointer(const volatile SimpleHandlerWrap* p)
+    {
+        return p;
+    }
+}
+#endif
 
 template <typename T>
 void apply_reader_simple(osmium::io::Reader &rd, T &h) {

--- a/lib/win_boost_fix.hpp
+++ b/lib/win_boost_fix.hpp
@@ -1,0 +1,20 @@
+#ifndef PYOSMIUM_WIN_BOOST_FIX_HPP
+#define PYOSMIUM_WIN_BOOST_FIX_HPP
+
+// workarodund for Visual Studio 2015 Update 3
+// https://connect.microsoft.com/VisualStudio/Feedback/Details/2852624
+#if (_MSC_VER > 1800 && _MSC_FULL_VER > 190023918)
+namespace boost {
+
+    template <>
+    const volatile osmium::index::map::Map<unsigned __int64,class osmium::Location>*
+    get_pointer(const volatile osmium::index::map::Map<unsigned __int64,
+                class osmium::Location> *c)
+    {
+       return c;
+    }
+}
+#endif
+
+
+#endif

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -75,7 +75,7 @@ def create_osm_file(data):
        the memberlist.
     """
     data.sort(key=lambda x:('NWR'.find(x['type']), x['id']))
-    with tempfile.NamedTemporaryFile(dir='/tmp', suffix='.osm', delete=False) as fd:
+    with tempfile.NamedTemporaryFile(dir=tempfile.gettempdir(), suffix='.osm', delete=False) as fd:
         fname = fd.name
         fd.write("<?xml version='1.0' encoding='UTF-8'?>\n".encode('utf-8'))
         fd.write('<osm version="0.6" generator="test-pyosmium" timestamp="2014-08-26T20:22:02Z">\n'.encode('utf-8'))
@@ -89,7 +89,7 @@ def create_osm_file(data):
     return fname
 
 def create_opl_file(data):
-    with tempfile.NamedTemporaryFile(dir='/tmp', suffix='.opl', delete=False) as fd:
+    with tempfile.NamedTemporaryFile(dir=tempfile.gettempdir(), suffix='.opl', delete=False) as fd:
         fname = fd.name
         fd.write(dedent(data).encode('utf-8'))
         fd.write(b'\n')

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -23,7 +23,7 @@ else:
 
 @contextmanager
 def WriteExpect(expected):
-    fname = tempfile.mktemp(dir='/tmp', suffix='.opl')
+    fname = tempfile.mktemp(dir=tempfile.gettempdir(), suffix='.opl')
     writer = o.SimpleWriter(fname, 1024*1024)
     try:
         yield writer


### PR DESCRIPTION
This is #35 with some cleanup of setup.py. Visual C++ has a nifty auto-linking feature which means we don't need to care about the exact name of the boost library. Makes the code quite a bit more simple.

I've also tried to add python 2.7 to the matrix but that fails because half the include paths are missing. @alex85k you said that you had that working already. Is there any special treatment required?