### PR TITLE
add cookie_support for internal download

### DIFF
--- a/src/osmium/replication/server.py
+++ b/src/osmium/replication/server.py
@@ -30,9 +30,10 @@ class ReplicationServer(object):
         the full dataset again.
     """
 
-    def __init__(self, url, diff_type='osc.gz'):
+    def __init__(self, url, diff_type='osc.gz', str_cookie=None):
         self.baseurl = url
         self.diff_type = diff_type
+        self.str_cookie = str_cookie
 
     def collect_diffs(self, start_id, max_size=1024):
         """ Create a MergeInputReader and download diffs starting with sequence
@@ -248,10 +249,10 @@ class ReplicationServer(object):
             `sequence` and `timestamp` is returned, otherwise the function
             returns `None`.
         """
-        try:
-            response = urlrequest.urlopen(self.get_state_url(seq))
-        except:
-            return None
+        opener = urlrequest.build_opener()
+        opener.addheaders = [('Cookie', self.str_cookie.strip('\n'))]
+
+        response = opener.open(self.get_state_url(seq))
 
         ts = None
         seq = None
@@ -282,7 +283,10 @@ class ReplicationServer(object):
             (or `urllib2.HTTPError` in python2)
             if the file cannot be downloaded.
         """
-        return urlrequest.urlopen(self.get_diff_url(seq)).read()
+        opener = urlrequest.build_opener()
+        if self.str_cookie is not None:
+            opener.addheaders = [('Cookie', self.str_cookie.strip('\n'))]
+        return opener.open(self.get_diff_url(seq)).read()
 
 
     def get_state_url(self, seq):

--- a/src/osmium/replication/server.py
+++ b/src/osmium/replication/server.py
@@ -250,9 +250,12 @@ class ReplicationServer(object):
             returns `None`.
         """
         opener = urlrequest.build_opener()
-        opener.addheaders = [('Cookie', self.str_cookie.strip('\n'))]
-
-        response = opener.open(self.get_state_url(seq))
+        if self.str_cookie is not None:
+            opener.addheaders = [('Cookie', self.str_cookie.strip('\n'))]
+        try:
+            response = opener.open(self.get_state_url(seq))
+        except:
+            return None
 
         ts = None
         seq = None

--- a/test/test_replication.py
+++ b/test/test_replication.py
@@ -53,7 +53,7 @@ def test_get_diff_url():
     for i, o in data:
         assert_equals(o, svr.get_diff_url(i))
 
-@patch('osmium.replication.server.urlrequest.urlopen', new_callable=UrllibMock)
+@patch('osmium.replication.server.urlrequest.OpenerDirector.open', new_callable=UrllibMock)
 def test_get_state_valid(mock):
     mock.set_result("""\
         #Sat Aug 26 11:04:04 UTC 2017
@@ -79,7 +79,7 @@ def test_get_state_server_timeout(mock):
     svr = rserv.ReplicationServer("http://test.io")
     assert_is_none(svr.get_state_info())
 
-@patch('osmium.replication.server.urlrequest.urlopen', new_callable=UrllibMock)
+@patch('osmium.replication.server.urlrequest.OpenerDirector.open', new_callable=UrllibMock)
 def test_apply_diffs_count(mock):
     mock.set_script(("""\
         sequenceNumber=100
@@ -96,7 +96,7 @@ def test_apply_diffs_count(mock):
 
     assert_equals(h.counts, [1, 1, 1, 0])
 
-@patch('osmium.replication.server.urlrequest.urlopen', new_callable=UrllibMock)
+@patch('osmium.replication.server.urlrequest.OpenerDirector.open', new_callable=UrllibMock)
 def test_apply_diffs_without_simplify(mock):
     mock.set_script(("""\
         sequenceNumber=100
@@ -113,7 +113,7 @@ def test_apply_diffs_without_simplify(mock):
     assert_equals(100, svr.apply_diffs(h, 100, 10000, simplify=False))
     assert_equals([2, 1, 1, 0], h.counts)
 
-@patch('osmium.replication.server.urlrequest.urlopen', new_callable=UrllibMock)
+@patch('osmium.replication.server.urlrequest.OpenerDirector.open', new_callable=UrllibMock)
 def test_apply_diffs_with_simplify(mock):
     mock.set_script(("""\
         sequenceNumber=100
@@ -130,7 +130,7 @@ def test_apply_diffs_with_simplify(mock):
     assert_equals(100, svr.apply_diffs(h, 100, 10000, simplify=True))
     assert_equals([1, 1, 1, 0], h.counts)
 
-@patch('osmium.replication.server.urlrequest.urlopen', new_callable=UrllibMock)
+@patch('osmium.replication.server.urlrequest.OpenerDirector.open', new_callable=UrllibMock)
 def test_apply_with_location(mock):
     mock.set_script(("""\
         sequenceNumber=100
@@ -158,7 +158,7 @@ def test_apply_with_location(mock):
 
 
 
-@patch('osmium.replication.server.urlrequest.urlopen', new_callable=UrllibMock)
+@patch('osmium.replication.server.urlrequest.OpenerDirector.open', new_callable=UrllibMock)
 def test_apply_reader_without_simplify(mock):
     mock.set_script(("""\
         sequenceNumber=100
@@ -179,7 +179,7 @@ def test_apply_reader_without_simplify(mock):
     diffs.reader.apply(h, simplify=False)
     assert_equals([2, 1, 1, 0], h.counts)
 
-@patch('osmium.replication.server.urlrequest.urlopen', new_callable=UrllibMock)
+@patch('osmium.replication.server.urlrequest.OpenerDirector.open', new_callable=UrllibMock)
 def test_apply_reader_with_simplify(mock):
     mock.set_script(("""\
         sequenceNumber=100
@@ -199,7 +199,7 @@ def test_apply_reader_with_simplify(mock):
     diffs.reader.apply(h, simplify=True)
     assert_equals([1, 1, 1, 0], h.counts)
 
-@patch('osmium.replication.server.urlrequest.urlopen', new_callable=UrllibMock)
+@patch('osmium.replication.server.urlrequest.OpenerDirector.open', new_callable=UrllibMock)
 def test_apply_reader_with_location(mock):
     mock.set_script(("""\
         sequenceNumber=100

--- a/tools/pyosmium-up-to-date
+++ b/tools/pyosmium-up-to-date
@@ -21,12 +21,19 @@ there is still data available on the server (either because the size
 limit has been reached or there was a network error which could not be
 resolved). Any other error results in a return code larger than 1. The
 output file is guaranteed to be unmodified in that case.
+
+Some OSM data sources require a cookie to be sent with the HTTP requests. 
+Pyosmium-up-to-date does not fetch the cookie from these services for you. 
+The Cookie can be read from a plain text file containing the cookie only.
+A cookie file should look like this (example from the Geofabrik download service): :
+
+   gf_download_oauth="login|test-2018-04-12|7MisSGpxOGtHu4zRlPtIeADuY09mahpq-V80R4EceqBLOVtrXu2KQGuP8AyMuuuObUQx-iSOFVUDhnUePaYBB7nrSn-BO5F-MC0fLf5YXE8S1gO6Nc5u5vzIT4FQrDgvvSb61C0K-WDRa1G4TQdEZNBcgEweQdMjE_GqXiI1os_UZ1MSLdyVVRHLfpFF28iGfvUrrbXNOHpaK2qXXb-oTvSP78V5pUH_pzHAOOiJ_cHoJOMF59CbvSE9ybBK_SQo5FJ0npdPzEcn05NXrw=="; expires=Tue, 12 Jun 2018 16:35:23 GMT; HttpOnly
+
 """
 
 import re
 import sys
 import logging
-import os
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import datetime as dt
@@ -53,13 +60,12 @@ def update_from_osm_server(ts, options):
 def update_from_custom_server(url, seq, ts, options):
     """Update from a custom URL, simply using the diff sequence as is."""
 
-    cookiefile = options.cookie
-    with open(cookiefile) as f:
-        cookiefile = f.readlines()
-    cookie_join = '\n'.join(cookiefile)
-    str_cookie = cookie_join.rsplit(';', 3)
-    del str_cookie[1:4]
-    str_cookie = ''.join(str_cookie)
+    str_cookie = None
+    if options.cookie is not None:
+        with open(options.cookie, "r") as f:
+            cookiefile = f.read().strip()
+        str_cookie = cookiefile.split(';')[0]
+
 
     svr = rserv.ReplicationServer(url, "osc.gz", str_cookie)
     log.info("Using replication service at %s" % url)

--- a/tools/pyosmium-up-to-date
+++ b/tools/pyosmium-up-to-date
@@ -26,6 +26,7 @@ output file is guaranteed to be unmodified in that case.
 import re
 import sys
 import logging
+import os
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import datetime as dt
@@ -52,7 +53,15 @@ def update_from_osm_server(ts, options):
 def update_from_custom_server(url, seq, ts, options):
     """Update from a custom URL, simply using the diff sequence as is."""
 
-    svr = rserv.ReplicationServer(url)
+    cookiefile = options.cookie
+    with open(cookiefile) as f:
+        cookiefile = f.readlines()
+    cookie_join = '\n'.join(cookiefile)
+    str_cookie = cookie_join.rsplit(';', 3)
+    del str_cookie[1:4]
+    str_cookie = ''.join(str_cookie)
+
+    svr = rserv.ReplicationServer(url, "osc.gz", str_cookie)
     log.info("Using replication service at %s" % url)
 
     if seq is None:
@@ -174,6 +183,7 @@ def get_arg_parser(from_main=False):
     parser.add_argument('--force-update-of-old-planet', action='store_true',
                         dest='force_update',
                         help="Apply update even if the input data is really old.")
+    parser.add_argument('-c', '--cookie', dest='cookie', help="""For internal download: txt file for Cookie support""")
 
     return parser
 


### PR DESCRIPTION
the changed code snippets make it possible to download internal OSM files with pyosmium-up-to-date.
For the authentication, a .txt - file with a generated cookie header is necessary. (e.g. with https://github.com/geofabrik/sendfile_osm_oauth_protector/blob/master/oauth_cookie_client.py)

Add the file path with the new option:     -c /path/to/file/