### PR TITLE
Find libboost_python3-mt.dylib installed by MacPorts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,8 @@ suffixes = [ # Debian naming convention for version installed in parallel
              "-%d.%d" % (pyversion.major, pyversion.minor),
              # Darwin
              "%d%d" % (pyversion.major, pyversion.minor),
+             # Darwin installed by MacPorts
+             "%d-mt" % (pyversion.major),
              # standard suffix for Python3
              "%d" % (pyversion.major),
              # standard naming


### PR DESCRIPTION
MacPorts will install Boost-Python as something like the following
(for Python 3.5) when runng `port install boost +python35`:
`/opt/local/lib/libboost_python3-mt.dylib`

This library won't otherwise be found with the existing suffixes.