### PR TITLE
Coordinates type for pybind

### DIFF
--- a/lib/geom.cc
+++ b/lib/geom.cc
@@ -36,6 +36,18 @@ PYBIND11_MODULE(geom, m)
         .export_values()
     ;
 
+    py::class_<osmium::geom::Coordinates>(m, "Coordinates",
+        "Class representing coordinates")
+        .def(py::init<>())
+        .def(py::init<double, double>())
+        .def_readonly("x", &osmium::geom::Coordinates::x,
+            "(read-only) X coordinate.")
+        .def_readonly("y", &osmium::geom::Coordinates::y,
+            "(read-only) Y coordinate.")
+        .def("valid", &osmium::geom::Coordinates::valid,
+            "True if coordinates are valid")
+    ;
+
     m.def("haversine_distance",
           (double (*)(const osmium::WayNodeList&)) &og::haversine::distance,
           py::arg("list"),

--- a/lib/replication.cc
+++ b/lib/replication.cc
@@ -4,6 +4,7 @@
 #include <osmium/io/any_input.hpp>
 #include <osmium/handler.hpp>
 #include <osmium/visitor.hpp>
+#include "cast.h"
 
 namespace py = pybind11;
 

--- a/test/test_geom.py
+++ b/test/test_geom.py
@@ -3,6 +3,7 @@ import unittest
 
 from helpers import create_osm_file, osmobj, HandlerTestBase
 import osmium as o
+import osmium.geom
 
 wkbfab = o.geom.WKBFactory()
 
@@ -51,3 +52,9 @@ class TestWkbCreatePoly(HandlerTestBase, unittest.TestCase):
 
     def check_result(self):
         assert_equals(1, len(self.handler.wkbs))
+
+class TestLonLatToMercator(unittest.TestCase):
+    def test_1(self):
+        ret = osmium.geom.lonlat_to_mercator(osmium.geom.Coordinates(1,1))
+        self.assertAlmostEquals(ret.x, 111319.49079327)
+        self.assertAlmostEquals(ret.y, 111325.14285463)

--- a/test/test_replication.py
+++ b/test/test_replication.py
@@ -1,8 +1,8 @@
-from nose.tools import *
-import unittest
 from io import BytesIO
 from textwrap import dedent
+
 from helpers import mkdate, CountingHandler
+from nose.tools import *
 
 try:
     from urllib.error import URLError
@@ -16,6 +16,9 @@ except ImportError:
 
 import osmium as o
 import osmium.replication.server as rserv
+import osmium.replication
+import tempfile
+import datetime
 
 class UrllibMock(MagicMock):
 
@@ -227,3 +230,16 @@ def test_apply_reader_with_location(mock):
     diffs.reader.apply(h, idx="flex_mem")
 
     assert_equals(h.counts, [1, 1, 0, 0])
+
+def test_get_newest_change_from_file():
+    with tempfile.NamedTemporaryFile("w", suffix='.osc') as temp:
+        temp.write("""
+        <osmChange version="0.6" generator="OsmSax">
+        <create>
+        <node id="31337" version="1" timestamp="2018-10-29T03:56:07Z" uid="8369524" user="x" changeset="63965061" lat="55.8149396" lon="-4.2601767"/>
+        </create>
+        </osmChange>       
+        """)
+        temp.seek(0)
+        val = osmium.replication.newest_change_from_file(temp.name)
+        assert_equals(val, datetime.datetime(2018, 10, 29, 3, 56, 7, tzinfo=datetime.timezone.utc))

--- a/test/test_replication.py
+++ b/test/test_replication.py
@@ -19,6 +19,7 @@ import osmium.replication.server as rserv
 import osmium.replication
 import tempfile
 import datetime
+import time
 
 class UrllibMock(MagicMock):
 
@@ -242,4 +243,4 @@ def test_get_newest_change_from_file():
         """)
         temp.seek(0)
         val = osmium.replication.newest_change_from_file(temp.name)
-        assert_equals(val, datetime.datetime(2018, 10, 29, 3, 56, 7, tzinfo=datetime.timezone.utc))
+        assert_equals("Mon Oct 29 03:56:07 2018", val.ctime())


### PR DESCRIPTION
Added missing types in pybind port

Based on output generated by mypy/stubgen I noticed following problems:
* lack of osmium::geom::Coordinates on Python side (it is present in boost_python)
* use of osmium::Timestamp in replication.newest_change_from_file instead of datetime.datetime

Added simple test for the first case