### PR TITLE
Remove undefined variable - cookie_policy

### DIFF
--- a/tools/pyosmium-get-changes
+++ b/tools/pyosmium-get-changes
@@ -206,7 +206,7 @@ def main(args):
     svr = rserv.ReplicationServer(url)
     if options.cookie is not None:
         # According to the documentation, the cookie jar loads the file only if FileCookieJar.load is called.
-        cookie_jar = cookiejarlib.MozillaCookieJar(options.cookie, None, cookie_policy)
+        cookie_jar = cookiejarlib.MozillaCookieJar(options.cookie)
         cookie_jar.load(options.cookie)
         opener = urlrequest.build_opener(urlrequest.HTTPCookieProcessor(cookie_jar))
         svr.open_url = opener.open


### PR DESCRIPTION
I see following failures when try to use cookies with pyosmium-get-changes:
Traceback (most recent call last):
  File "/tmp/venv/bin/pyosmium-get-changes", line 243, in <module>
    exit(main(sys.argv[1:]))
  File "/tmp/venv/bin/pyosmium-get-changes", line 209, in main
    cookie_jar = cookiejarlib.MozillaCookieJar(options.cookie, None, cookie_policy)
NameError: name 'cookie_policy' is not defined

@Nakaner: FYI, I'm not sure, if you intended to set come policy here.