### PR TITLE
Catch dangling references when returning from callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
     - git clone --quiet --depth 1 https://github.com/mapbox/protozero.git contrib/protozero
     - git clone --quiet --depth 1 https://github.com/pybind/pybind11.git contrib/pybind11
     - if [ "$TRAVIS_OS_NAME" = 'osx' ]; then
-          pip${USE_PYTHON_VERSION} install -q nose mock shapely;
+          pip${USE_PYTHON_VERSION} install --user -q nose mock shapely;
       fi
 
 script:

--- a/lib/osm.cc
+++ b/lib/osm.cc
@@ -363,7 +363,9 @@ PYBIND11_MODULE(_osm, m) {
                                                        a.cend<osmium::OuterRing>()); },
                             py::keep_alive<0, 1>(),
              "Return an iterator over all outer rings of the multipolygon.")
-        .def("inner_rings", &osmium::Area::inner_rings, py::arg("outer_ring"),
+        .def("inner_rings", &osmium::Area::inner_rings,
+                            py::keep_alive<0, 1>(),
+             py::arg("outer_ring"),
              "Return an iterator over all inner rings of the multipolygon.")
     ;
 

--- a/lib/simple_handler.h
+++ b/lib/simple_handler.h
@@ -71,15 +71,15 @@ public:
     osmium::osm_entity_bits::type enabled_callbacks() override
     {
         auto callbacks = osmium::osm_entity_bits::nothing;
-        if (hasfunc("node"))
+        if (callback("node"))
             callbacks |= osmium::osm_entity_bits::node;
-        if (hasfunc("way"))
+        if (callback("way"))
             callbacks |= osmium::osm_entity_bits::way;
-        if (hasfunc("relation"))
+        if (callback("relation"))
             callbacks |= osmium::osm_entity_bits::relation;
-        if (hasfunc("area"))
+        if (callback("area"))
             callbacks |= osmium::osm_entity_bits::area;
-        if (hasfunc("changeset"))
+        if (callback("changeset"))
             callbacks |= osmium::osm_entity_bits::changeset;
 
         return callbacks;
@@ -89,36 +89,76 @@ public:
     void node(osmium::Node const *n) override
     {
         pybind11::gil_scoped_acquire acquire;
-        PYBIND11_OVERLOAD(void, SimpleHandler, node, n);
+        auto func = callback("node");
+        if (func) {
+            auto obj = pybind11::cast(n, pybind11::return_value_policy::reference);
+
+            func(obj);
+
+            if (obj.ref_count() != 1)
+                throw std::runtime_error("Node callback keeps reference to OSM object. This is not allowed.");
+        }
     }
 
     void way(osmium::Way const *w) override
     {
         pybind11::gil_scoped_acquire acquire;
-        PYBIND11_OVERLOAD(void, SimpleHandler, way, w);
+        auto func = callback("way");
+        if (func) {
+            auto obj = pybind11::cast(w, pybind11::return_value_policy::reference);
+
+            func(obj);
+
+            if (obj.ref_count() != 1)
+                throw std::runtime_error("Way callback keeps reference to OSM object. This is not allowed.");
+        }
     }
 
     void relation(osmium::Relation const *r) override
     {
         pybind11::gil_scoped_acquire acquire;
-        PYBIND11_OVERLOAD(void, SimpleHandler, relation, r);
+        auto func = callback("relation");
+        if (func) {
+            auto obj = pybind11::cast(r, pybind11::return_value_policy::reference);
+
+            func(obj);
+
+            if (obj.ref_count() != 1)
+                throw std::runtime_error("Relation callback keeps reference to OSM object. This is not allowed.");
+        }
     }
 
     void changeset(osmium::Changeset const *c) override
     {
         pybind11::gil_scoped_acquire acquire;
-        PYBIND11_OVERLOAD(void, SimpleHandler, changeset, c);
+        auto func = callback("changeset");
+        if (func) {
+            auto obj = pybind11::cast(c, pybind11::return_value_policy::reference);
+
+            func(obj);
+
+            if (obj.ref_count() != 1)
+                throw std::runtime_error("Changeset callback keeps reference to OSM object. This is not allowed.");
+        }
     }
 
     void area(osmium::Area const *a) override
     {
         pybind11::gil_scoped_acquire acquire;
-        PYBIND11_OVERLOAD(void, SimpleHandler, area, a);
+        auto func = callback("area");
+        if (func) {
+            auto obj = pybind11::cast(a, pybind11::return_value_policy::reference);
+
+            func(obj);
+
+            if (obj.ref_count() != 1)
+                throw std::runtime_error("Area callback keeps reference to OSM object. This is not allowed.");
+        }
     }
 
 private:
-    bool hasfunc(char const *name)
-    { return (bool)pybind11::get_overload(static_cast<SimpleHandler const *>(this), name); }
+    pybind11::function callback(char const *name)
+    { return pybind11::get_overload(static_cast<SimpleHandler const *>(this), name); }
 };
 
 #endif // PYOSMIUM_SIMPLE_HANDLER_HPP

--- a/test/test_dangling_references.py
+++ b/test/test_dangling_references.py
@@ -1,0 +1,178 @@
+# vim: set fileencoding=utf-8 :
+from nose.tools import *
+import unittest
+
+from helpers import create_osm_file
+
+import osmium as o
+
+class DanglingReferenceBase(object):
+    """ Base class for tests that try to keep a reference to the object
+        that was handed into the callback. We expect that the handler
+        bails out with a runtime error in such a case.
+    """
+
+    node = None
+    way = None
+    relation = None
+    area = None
+    refkeeper = []
+
+    def keep(self, obj):
+        self.refkeeper.append(obj)
+
+    def test_keep_reference(self):
+        h = o.make_simple_handler(node=self.node, way=self.way,
+                                  relation=self.relation, area=self.area)
+        with self.assertRaisesRegex(RuntimeError, "callback keeps reference"):
+            h.apply_file('example-test.pbf')
+        assert_greater(len(self.refkeeper), 0)
+        self.refkeeper.clear()
+
+
+class TestKeepNodeRef(DanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        self.keep(n)
+
+class TestKeepWayRef(DanglingReferenceBase, unittest.TestCase):
+
+    def way(self, w):
+        self.keep(w)
+
+class TestKeepRelationRef(DanglingReferenceBase, unittest.TestCase):
+
+    def relation(self, r):
+        self.keep(r)
+
+class TestKeepAreaRef(DanglingReferenceBase, unittest.TestCase):
+
+    def area(self, a):
+        self.keep(a)
+
+class TestKeepNodeTagsRef(DanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        self.keep(n.tags)
+
+class TestKeepWayTagsRef(DanglingReferenceBase, unittest.TestCase):
+
+    def way(self, w):
+        self.keep(w.tags)
+
+class TestKeepRelationTagsRef(DanglingReferenceBase, unittest.TestCase):
+
+    def relation(self, r):
+        self.keep(r.tags)
+
+class TestKeepAreaTagsRef(DanglingReferenceBase, unittest.TestCase):
+
+    def area(self, a):
+        self.keep(a.tags)
+
+class TestKeepTagListIterator(DanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        self.keep(n.tags.__iter__())
+
+class TestKeepSingleTag(DanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        for t in n.tags:
+            self.keep(t)
+
+class TestKeepOuterRingIterator(DanglingReferenceBase, unittest.TestCase):
+
+    def area(self, r):
+        self.keep(r.outer_rings())
+
+class TestKeepOuterRing(DanglingReferenceBase, unittest.TestCase):
+
+    def area(self, r):
+        for ring in r.outer_rings():
+            self.keep(ring)
+
+class TestKeepInnerRingIterator(DanglingReferenceBase, unittest.TestCase):
+
+    def area(self, r):
+        for ring in r.outer_rings():
+            self.keep(r.inner_rings(ring))
+
+class TestKeepInnerRing(DanglingReferenceBase, unittest.TestCase):
+
+    def area(self, r):
+        for outer in r.outer_rings():
+            for inner in r.inner_rings(outer):
+                self.keep(inner)
+
+class TestKeepRelationMemberIterator(DanglingReferenceBase, unittest.TestCase):
+
+    def relation(self, r):
+        self.keep(r.members)
+
+class TestKeepRelationMember(DanglingReferenceBase, unittest.TestCase):
+
+    def relation(self, r):
+        for m in r.members:
+            self.keep(m)
+
+
+class NotADanglingReferenceBase(object):
+    """ Base class for tests that ensure that the callback does not
+        bail out because of dangling references when POD types are
+        kept.
+    """
+
+    node = None
+    way = None
+    relation = None
+    area = None
+    refkeeper = []
+
+    def keep(self, obj):
+        self.refkeeper.append(obj)
+
+    def test_keep_reference(self):
+        h = o.make_simple_handler(node=self.node, way=self.way,
+                                  relation=self.relation, area=self.area)
+        # Does not rise a dangling reference excpetion
+        h.apply_file('example-test.pbf')
+        assert_greater(len(self.refkeeper), 0)
+        self.refkeeper.clear()
+
+class TestKeepId(NotADanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        self.keep(n.id)
+
+class TestKeepChangeset(NotADanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        self.keep(n.changeset)
+
+class TestKeepUid(NotADanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        self.keep(n.uid)
+
+class TestKeepUser(NotADanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        self.keep(n.user)
+
+class TestKeepLocation(NotADanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        self.keep(n.location)
+
+class TestKeepKey(NotADanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        for t in n.tags:
+            self.keep(t.k)
+
+class TestKeepValue(NotADanglingReferenceBase, unittest.TestCase):
+
+    def node(self, n):
+        for t in n.tags:
+            self.keep(t.v)


### PR DESCRIPTION
Using Python's internal reference counting, we can check if
the callback has kept any references to the OSM object that
was handed in. Using pybind11's the keep_alive() policy this
can even be extended to members of the object like the tag
or node list. If dangling references are detected we bail out
with an exception.

Solves the issue that users got unmotivated segfaults when
keeping references.

