### PR TITLE
doc: add a section about stale references

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@ and profits from its fast implementation.
 
    intro
    reference
+   troubleshooting
    tools
     
 

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -1,0 +1,24 @@
+Troubleshooting
+===============
+
+``RuntimeError: callback keeps reference to OSM object``
+--------------------------------------------------------
+
+One of your callbacks tries to store the OSM object outside the scope of
+the function. This is not allowed because for performance reasons, Osmium
+gives you only a temporary view of the data. You must make a (deep) copy of all
+data that you want to use later outside of the callback. See also
+:ref:`intro-copying-data-from-object`.
+
+Segfault when importing another library
+---------------------------------------
+
+There have been cases reported where pyosmium does not play well with other
+python libraries that are compiled. If you see a segmentation fault when
+importing pyosmium together with other libraries, try installing the
+source code version of pyosmium. This can be done with pip::
+
+    pip install --no-binary :all: osmium
+
+You need to first install the depencies listed in the README.
+


### PR DESCRIPTION
Adds an example how not to save objects in the handler. Also adds
a troubleshooting section that lists the runtime error that
pyosmium now throws.

In addition, adds a troubleshooting section about the segfaults
for now.