### PR TITLE
Added socket timeout of 30 seconds in open_url

### DIFF
--- a/src/osmium/replication/server.py
+++ b/src/osmium/replication/server.py
@@ -55,7 +55,7 @@ class ReplicationServer(object):
                 svr = ReplicationServer()
                 svr.open_url = my_open_url
         """
-        return urlrequest.urlopen(url)
+        return urlrequest.urlopen(url, timeout=30)
 
     def collect_diffs(self, start_id, max_size=1024):
         """ Create a MergeInputReader and download diffs starting with sequence


### PR DESCRIPTION
If the system that is running the updater does not have a default timeout, the process will hang infinitely.  I added a timeout of 30 seconds in server.py to catch these instances