### PR TITLE
Set flag that this is a history file also on File object

### DIFF
--- a/src/osmium/replication/server.py
+++ b/src/osmium/replication/server.py
@@ -186,6 +186,7 @@ class ReplicationServer(object):
         else:
             of = oio.File(outfile, outformat)
 
+        of.has_multiple_object_versions = has_history
         writer = oio.Writer(of, h)
 
         log.debug("Merging changes into OSM file.")


### PR DESCRIPTION
When writing an OSM file, the osmium::io::File object decides whether
the "history" flag is actually set in the file, not the
osmium::io::Header object. This is rather confusing, but currently how
libosmium handles this. Usually this doesn't matter, because a history
file will be named .osh.pbf for instance instead of .osm.pbf, in which
case it is clear what type of file is meant. But when the file is only
named .pbf only setting the flag in the header will not work.