### PR TITLE
Consistent logging format with leading ISO date in tools

### DIFF
--- a/tools/pyosmium-get-changes
+++ b/tools/pyosmium-get-changes
@@ -175,7 +175,8 @@ def get_arg_parser(from_main=False):
 
 def main(args):
     logging.basicConfig(stream=sys.stderr,
-                        format='%(levelname)s: %(message)s')
+                        format='%(asctime)s %(levelname)s: %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S')
 
     options = get_arg_parser(from_main=True).parse_args(args)
 

--- a/tools/pyosmium-up-to-date
+++ b/tools/pyosmium-up-to-date
@@ -217,7 +217,8 @@ def open_with_cookie(url):
 
 if __name__ == '__main__':
     logging.basicConfig(stream=sys.stderr,
-                        format='%(asctime)s %(levelname)s: %(message)s')
+                        format='%(asctime)s %(levelname)s: %(message)s'),
+                        datefmt='%Y-%m-%d %H:%M:%S')
 
     options = get_arg_parser(from_main=True).parse_args()
     log.setLevel(max(3 - options.loglevel, 0) * 10)


### PR DESCRIPTION
Use the same logging format in both pyosmium-get-changes and
pyosmium-up-to-date with leading ISO date without fractional seconds.