### PR TITLE
Update required libosmium version to 2.16.0 and add LZ4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install packages
-              run: sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev
+              run: sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev liblz4-dev
 
             - uses: ./.github/actions/install-dependencies
 
@@ -48,7 +48,7 @@ jobs:
                   python-version: 3.5
 
             - name: Install packages
-              run: sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev
+              run: sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev liblz4-dev
 
             - uses: ./.github/actions/install-dependencies
 
@@ -88,7 +88,7 @@ jobs:
                   python-version: 3.9
 
             - name: Install packages
-              run: sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev
+              run: sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev liblz4-dev
 
             - uses: ./.github/actions/install-dependencies
 
@@ -124,7 +124,7 @@ jobs:
                   python-version: 3
 
             - name: Install packages
-              run: brew install boost geos
+              run: brew install boost geos lz4
               shell: bash
 
             - uses: ./.github/actions/install-dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,27 @@ cmake_minimum_required(VERSION 2.8.12)
 project(pyosmium)
 set(PACKAGE_VERSION 3.0.1)
 
+option(WITH_LZ4 "Build with lz4 support for PBF files" ON)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-find_package(Osmium 2.15 REQUIRED COMPONENTS io pbf xml)
+find_package(Osmium 2.16 REQUIRED COMPONENTS io pbf xml)
+
+if(WITH_LZ4)
+find_package(LZ4)
+
+    if(LZ4_FOUND)
+        message(STATUS "lz4 library found, compiling with it")
+        add_definitions(-DOSMIUM_WITH_LZ4)
+        include_directories(SYSTEM ${LZ4_INCLUDE_DIRS})
+        list(APPEND OSMIUM_LIBRARIES ${LZ4_LIBRARIES})
+    else()
+        message(WARNING "lz4 library not found, compiling without it")
+    endif()
+else()
+    message(STATUS "Building without lz4 support: Set WITH_LZ4=ON to change this")
+endif()
+
 include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS} ${PROTOZERO_INCLUDE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ command installs all required packages:
 
 pyosmium has the following dependencies:
 
- * [libosmium](https://github.com/osmcode/libosmium)
+ * [libosmium](https://github.com/osmcode/libosmium) >= 2.16.0
  * [protozero](https://github.com/mapbox/protozero)
  * [cmake](https://cmake.org/)
  * [Pybind11](https://github.com/pybind/pybind11) >= 2.2

--- a/cmake/FindLZ4.cmake
+++ b/cmake/FindLZ4.cmake
@@ -1,0 +1,38 @@
+find_path(LZ4_INCLUDE_DIR
+  NAMES lz4.h
+  DOC "lz4 include directory")
+mark_as_advanced(LZ4_INCLUDE_DIR)
+find_library(LZ4_LIBRARY
+  NAMES lz4 liblz4
+  DOC "lz4 library")
+mark_as_advanced(LZ4_LIBRARY)
+
+if (LZ4_INCLUDE_DIR)
+  file(STRINGS "${LZ4_INCLUDE_DIR}/lz4.h" _lz4_version_lines
+    REGEX "#define[ \t]+LZ4_VERSION_(MAJOR|MINOR|RELEASE)")
+  string(REGEX REPLACE ".*LZ4_VERSION_MAJOR *\([0-9]*\).*" "\\1" _lz4_version_major "${_lz4_version_lines}")
+  string(REGEX REPLACE ".*LZ4_VERSION_MINOR *\([0-9]*\).*" "\\1" _lz4_version_minor "${_lz4_version_lines}")
+  string(REGEX REPLACE ".*LZ4_VERSION_RELEASE *\([0-9]*\).*" "\\1" _lz4_version_release "${_lz4_version_lines}")
+  set(LZ4_VERSION "${_lz4_version_major}.${_lz4_version_minor}.${_lz4_version_release}")
+  unset(_lz4_version_major)
+  unset(_lz4_version_minor)
+  unset(_lz4_version_release)
+  unset(_lz4_version_lines)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LZ4
+  REQUIRED_VARS LZ4_LIBRARY LZ4_INCLUDE_DIR
+  VERSION_VAR LZ4_VERSION)
+
+if (LZ4_FOUND)
+  set(LZ4_INCLUDE_DIRS "${LZ4_INCLUDE_DIR}")
+  set(LZ4_LIBRARIES "${LZ4_LIBRARY}")
+
+  if (NOT TARGET LZ4::LZ4)
+    add_library(LZ4::LZ4 UNKNOWN IMPORTED)
+    set_target_properties(LZ4::LZ4 PROPERTIES
+      IMPORTED_LOCATION "${LZ4_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${LZ4_INCLUDE_DIR}")
+  endif ()
+endif ()

--- a/cmake/FindOsmium.cmake
+++ b/cmake/FindOsmium.cmake
@@ -34,6 +34,7 @@
 #      gdal       - include if you want to use any of the OGR functions
 #      proj       - include if you want to use any of the Proj.4 functions
 #      sparsehash - include if you use the sparsehash index
+#      lz4        - include support for LZ4 compression of PBF files
 #
 #    You can check for success with something like this:
 #
@@ -116,14 +117,21 @@ if(Osmium_USE_PBF)
     find_package(Threads)
     find_package(Protozero 1.6.3)
 
+    if(Osmium_USE_LZ4)
+        find_package(LZ4 REQUIRED)
+        add_definitions(-DOSMIUM_WITH_LZ4)
+    endif()
+
     list(APPEND OSMIUM_EXTRA_FIND_VARS ZLIB_FOUND Threads_FOUND PROTOZERO_INCLUDE_DIR)
     if(ZLIB_FOUND AND Threads_FOUND AND PROTOZERO_FOUND)
         list(APPEND OSMIUM_PBF_LIBRARIES
             ${ZLIB_LIBRARIES}
+            ${LZ4_LIBRARIES}
             ${CMAKE_THREAD_LIBS_INIT}
         )
         list(APPEND OSMIUM_INCLUDE_DIRS
             ${ZLIB_INCLUDE_DIR}
+            ${LZ4_INCLUDE_DIRS}
             ${PROTOZERO_INCLUDE_DIR}
         )
     else()


### PR DESCRIPTION
Libosmium 2.16.0 now supports reading and writing PBF files with
internal LZ4 compression of blocks. This commit enables this by default
for pyosmium if the lz4 library is found. It can be disabled by setting
the CMake option WITH_LZ4 to OFF. LZ4 (de)compression is much faster
than zlib compression. This is useful for mostly internally used files.