### PR TITLE
Fix state download when getting some network issues

### DIFF
--- a/src/osmium/replication/server.py
+++ b/src/osmium/replication/server.py
@@ -282,7 +282,7 @@ class ReplicationServer:
             returns `None`. `retries` sets the number of times the download
             is retried when pyosmium detects a truncated state file.
         """
-        for _ in range(retries + 1):
+        for trial in range(retries + 1):
             try:
                 response = self.open_url(self.make_request(self.get_state_url(seq)))
             except Exception as err:
@@ -314,6 +314,8 @@ class ReplicationServer:
 
             if ts is not None and seq is not None:
                 return OsmosisState(sequence=seq, timestamp=ts)
+
+            LOG.debug("Loading state info %s retrying again (trial #%d)", seq, trial)
 
         return None
 

--- a/src/osmium/replication/server.py
+++ b/src/osmium/replication/server.py
@@ -287,7 +287,7 @@ class ReplicationServer:
                 response = self.open_url(self.make_request(self.get_state_url(seq)))
             except Exception as err:
                 LOG.debug("Loading state info %s failed with: %s", seq, str(err))
-                return None
+                continue # retry again in case it is a temporary network issue
 
             ts = None
             seq = None


### PR DESCRIPTION
Hi,

I'm sometime getting network issues to download diff/state file in the middle of an update of an extract. When getting a connection timeout on the state download, all the diffs files already downloaded are lost, and I have to restart the whole download.

This patch fixes this issue, by retrying the download of the state file, which means that we are able to update the extract with the diffs already downloaded.

I have also added a test to cover this testcase.

Thanks!