### PR TITLE
Changes file cannot be overwritten

### DIFF
--- a/doc/updating_osm_data.rst
+++ b/doc/updating_osm_data.rst
@@ -181,6 +181,8 @@ All other error codes indicate fatal errors.
 A simple shell script can look like this::
 
   while true; do
+    # pyosmium-get-changes would not overwrite an existing changes file
+    rm -f newchange.osc.gz
     # get the next batch of changes
     pyosmium-get-changes -f sequence.state -o newchange.osc.gz
     # save the return code


### PR DESCRIPTION
The example script for _Continuously updating a database_ was fixed to delete the `newchange.osc.gz` file, if exists, before executing `pyosmium-get-changes`.

Otherwise, at the second iteration of the script  `pyosmium-get-changes` would issue an error:
```
Traceback (most recent call last):
  File "/usr/bin/pyosmium-get-changes", line 243, in <module>
    exit(main(sys.argv[1:]))
  File "/usr/bin/pyosmium-get-changes", line 224, in main
    outhandler = WriteHandler(options.outfile)
RuntimeError: Open failed for 'newchange.osc.gz': File exists
```