### PR TITLE
Update updating_osm_data.rst

### DIFF
--- a/doc/updating_osm_data.rst
+++ b/doc/updating_osm_data.rst
@@ -84,7 +84,7 @@ Updating larger amounts of data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When used without any parameters, pyosmium downloads at a maximum about
-1GB of changes. That corresponds to about 3 days of planet-wide changes.
+100MB of changes. That corresponds to about 6 hours of planet-wide changes.
 You can increase the amount using the additional `--size` parameter::
 
   pyosmium-up-to-date --size=10000 planet.osm.pbf


### PR DESCRIPTION
The default size is 100MB, not 1GB
See https://github.com/osmcode/pyosmium/blob/a28a910462193fd9cd9879eb3e8c0906f327957d/tools/pyosmium-get-changes#L146-L147