### PR TITLE
Also support pybuild directory for doc build.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,11 +28,17 @@ if not os.path.exists(build_dir):
     build_dir = "../build/lib.%s-%s" % (sysconfig.get_platform(),
                                         sys.implementation.cache_tag)
     if not os.path.exists(build_dir):
-        print("""
-            Compiled version of pyosmium not found, please build pyosmium for Python {}.{}
-            before building the documentation.
-            """.format(*sys.version_info))
-        raise RuntimeError("Cannot find pyosmium")
+        # pybuild
+        build_dir = "../.pybuild/cpython3_%s.%s_pyosmium/build" % (
+            sys.version_info[0], sys.version_info[1]
+        )
+
+        if not os.path.exists(build_dir):
+            print("""
+                Compiled version of pyosmium not found, please build pyosmium for Python {}.{}
+                before building the documentation.
+                """.format(*sys.version_info))
+            raise RuntimeError("Cannot find pyosmium")
 
 # insert after the current directory
 sys.path.insert(0, os.path.normpath(os.path.join(os.path.abspath('.'), build_dir)))


### PR DESCRIPTION
The Debian package build for 3.4.0 because neither of the build directory paths is used.

The 3.3.0 build did not fail when the build directory does not exist, `PYTHONPATH` was set in the environment to the [pybuild](https://wiki.debian.org/Python/Pybuild) directory to make the doc build work.

To not raise the exception the pybuild directory needs to be tested too.