### PR TITLE
Simplify handling of custom request parameters

### DIFF
--- a/src/osmium/replication/server.py
+++ b/src/osmium/replication/server.py
@@ -37,25 +37,14 @@ class ReplicationServer:
         replication service serves something other than osc.gz files, set
         the `diff_type` to the given file suffix.
 
-        `extra_parameters` may be used to define additional parameters to be
-        handed to the `requests.get()` method when downloading files. This
-        may be used to set custom headers, timeouts and similar parameters.
-        See the `requests documentation <https://requests.readthedocs.io/en/latest/api/?highlight=get#requests.request>`_
-        for possible parameters. The default is to set a timeout of 60 sec
-        and enable streaming download.
-
         ReplicationServer may be used as a context manager. In this case, it
         internally keeps a connection to the server making downloads faster.
     """
 
-    def __init__(self, url: str, diff_type: str = 'osc.gz',
-                 extra_request_params: Optional[Mapping[str, Any]] = None) -> None:
+    def __init__(self, url: str, diff_type: str = 'osc.gz') -> None:
         self.baseurl = url
         self.diff_type = diff_type
-        if extra_request_params is None:
-            self.extra_request_params = dict(timeout=60, stream=True)
-        else:
-            self.extra_request_params = extra_request_params
+        self.extra_request_params: Mapping[str, Any] = dict(timeout=60, stream=True)
         self.session: Optional[requests.Session] = None
 
     def close(self) -> None:
@@ -71,6 +60,16 @@ class ReplicationServer:
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         self.close()
+
+    def set_request_parameter(self, key: str, value: Any) -> None:
+        """ Set a parameter which will be handed to the requests library
+            when calling `requests.get()`. This
+            may be used to set custom headers, timeouts and similar parameters.
+            See the `requests documentation <https://requests.readthedocs.io/en/latest/api/?highlight=get#requests.request>`_
+            for possible parameters. Per default, a timeout of 60 sec is set
+            and streaming download enabled.
+        """
+        self.extra_request_params[key] = value
 
     def make_request(self, url: str) -> urlrequest.Request:
         headers = {"User-Agent" : f"pyosmium/{version.pyosmium_release}"}

--- a/src/osmium/replication/server.py
+++ b/src/osmium/replication/server.py
@@ -32,6 +32,18 @@ class ReplicationServer:
         Replication change files allow to keep local OSM data up-to-date without
         downloading the full dataset again.
 
+        `url` contains the base URL of the replication service. This is the
+        directory that contains the state file with the current state. If the
+        replication service serves something other than osc.gz files, set
+        the `diff_type` to the given file suffix.
+
+        `extra_parameters` may be used to define additional parameters to be
+        handed to the `requests.get()` method when downloading files. This
+        may be used to set custom headers, timeouts and similar parameters.
+        See the `requests documentation <https://requests.readthedocs.io/en/latest/api/?highlight=get#requests.request>`_
+        for possible parameters. The default is to set a timeout of 60 sec
+        and enable streaming download.
+
         ReplicationServer may be used as a context manager. In this case, it
         internally keeps a connection to the server making downloads faster.
     """
@@ -67,20 +79,6 @@ class ReplicationServer:
     def open_url(self, url: urlrequest.Request) -> Any:
         """ Download a resource from the given URL and return a byte sequence
             of the content.
-
-            This method has no support for cookies or any special authentication
-            methods. If you need these, you have to provide your own custom URL
-            opener. Overwrite open_url() with a method that receives an
-            urlrequest.Request object and returns a ByteIO-like object or a
-            requests.Response.
-
-            Example::
-
-                opener = urlrequest.build_opener()
-                opener.addheaders = [('X-Fancy-Header', 'important_content')]
-
-                svr = ReplicationServer()
-                svr.open_url = opener.open
         """
         if 'headers' in self.extra_request_params:
             get_params = self.extra_request_params

--- a/test/test_pyosmium_get_changes.py
+++ b/test/test_pyosmium_get_changes.py
@@ -48,13 +48,6 @@ class TestPyosmiumGetChanges:
         monkeypatch.setattr(osmium.replication.server.requests.Session, "get", mock_get)
 
 
-    @pytest.fixture
-    def mock_urllib(self, monkeypatch):
-        def mock_get(_, url, **kwargs):
-            return BytesIO(self.urls[url.get_full_url()])
-        monkeypatch.setattr(self.script['urlrequest'].OpenerDirector, "open", mock_get)
-
-
     def url(self, url, result):
         self.urls[url] = dedent(result).encode()
 
@@ -103,7 +96,7 @@ class TestPyosmiumGetChanges:
         assert fname.read_text() == '453'
 
 
-    def test_init_date_with_cookie(self, capsys, tmp_path, mock_urllib):
+    def test_init_date_with_cookie(self, capsys, tmp_path, mock_requests):
         self.url('https://planet.osm.org/replication/minute//state.txt',
                  """\
                     sequenceNumber=100

--- a/tools/pyosmium-get-changes
+++ b/tools/pyosmium-get-changes
@@ -245,6 +245,7 @@ def main(args):
         cookie_jar.save(options.cookie)
 
     if endseq is None:
+        log.error("Error while downloading diffs.")
         return 3
 
     if options.outfile != '-' or options.seq_file is not None:

--- a/tools/pyosmium-get-changes
+++ b/tools/pyosmium-get-changes
@@ -27,17 +27,14 @@ cookies to the server and will save received cookies to the jar file.
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, ArgumentTypeError
 import datetime as dt
+import http.cookiejar as cookiejarlib
+
 from osmium.replication import server as rserv
 from osmium.replication import newest_change_from_file
 from osmium.replication.utils import get_replication_header
 from osmium.version import pyosmium_release
 from osmium import SimpleHandler, WriteHandler
 
-try:
-    import http.cookiejar as cookiejarlib
-except ImportError:
-    import cookielib as cookiejarlib
-import urllib.request as urlrequest
 
 import re
 import sys
@@ -213,14 +210,12 @@ def main(args):
     extra_request_params = dict(stream=True,
                                 timeout=options.socket_timeout or None)
 
-    with rserv.ReplicationServer(url, extra_request_params=extra_request_params) as svr:
-        if options.cookie is not None:
-            # According to the documentation, the cookie jar loads the file only if FileCookieJar.load is called.
-            cookie_jar = cookiejarlib.MozillaCookieJar(options.cookie)
-            cookie_jar.load(options.cookie)
-            opener = urlrequest.build_opener(urlrequest.HTTPCookieProcessor(cookie_jar))
-            svr.open_url = opener.open
+    if options.cookie is not None:
+        cookie_jar = cookiejarlib.MozillaCookieJar(options.cookie)
+        cookie_jar.load(options.cookie)
+        extra_request_params['cookies'] = cookie_jar
 
+    with rserv.ReplicationServer(url, extra_request_params=extra_request_params) as svr:
         startseq = options.start.get_sequence(svr)
         if startseq is None:
             log.error("Cannot read state file from server. Is the URL correct?")

--- a/tools/pyosmium-get-changes
+++ b/tools/pyosmium-get-changes
@@ -27,7 +27,6 @@ cookies to the server and will save received cookies to the jar file.
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, ArgumentTypeError
 import datetime as dt
-import socket
 from osmium.replication import server as rserv
 from osmium.replication import newest_change_from_file
 from osmium.replication.utils import get_replication_header
@@ -211,9 +210,10 @@ def main(args):
             or 'https://planet.osm.org/replication/minute/'
     logging.info("Using replication server at %s" % url)
 
-    socket.setdefaulttimeout(options.socket_timeout)
+    extra_request_params = dict(stream=True,
+                                timeout=options.socket_timeout or None)
 
-    with rserv.ReplicationServer(url) as svr:
+    with rserv.ReplicationServer(url, extra_request_params=extra_request_params) as svr:
         if options.cookie is not None:
             # According to the documentation, the cookie jar loads the file only if FileCookieJar.load is called.
             cookie_jar = cookiejarlib.MozillaCookieJar(options.cookie)

--- a/tools/pyosmium-get-changes
+++ b/tools/pyosmium-get-changes
@@ -27,7 +27,7 @@ cookies to the server and will save received cookies to the jar file.
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, ArgumentTypeError
 import datetime as dt
-import http.cookiejar as cookiejarlib
+import http.cookiejar
 
 from osmium.replication import server as rserv
 from osmium.replication import newest_change_from_file
@@ -207,15 +207,14 @@ def main(args):
             or 'https://planet.osm.org/replication/minute/'
     logging.info("Using replication server at %s" % url)
 
-    extra_request_params = dict(stream=True,
-                                timeout=options.socket_timeout or None)
+    with rserv.ReplicationServer(url) as svr:
+        svr.set_request_parameter('timeout', options.socket_timeout or None)
 
-    if options.cookie is not None:
-        cookie_jar = cookiejarlib.MozillaCookieJar(options.cookie)
-        cookie_jar.load(options.cookie)
-        extra_request_params['cookies'] = cookie_jar
+        if options.cookie is not None:
+            cookie_jar = http.cookiejar.MozillaCookieJar(options.cookie)
+            cookie_jar.load(options.cookie)
+            svr.set_request_parameter('cookies', cookie_jar)
 
-    with rserv.ReplicationServer(url, extra_request_params=extra_request_params) as svr:
         startseq = options.start.get_sequence(svr)
         if startseq is None:
             log.error("Cannot read state file from server. Is the URL correct?")

--- a/tools/pyosmium-up-to-date
+++ b/tools/pyosmium-up-to-date
@@ -61,16 +61,15 @@ def update_from_osm_server(ts, options):
 
 def update_from_custom_server(url, seq, ts, options):
     """Update from a custom URL, simply using the diff sequence as is."""
-    extra_request_params = dict(stream=True,
-                                timeout=options.socket_timeout or None)
-
-    if options.cookie is not None:
-        cookie_jar = http.cookiejar.MozillaCookieJar(options.cookie)
-        cookie_jar.load(options.cookie)
-        extra_request_params['cookies'] = cookie_jar
-
-    with rserv.ReplicationServer(url, "osc.gz", extra_request_params=extra_request_params) as svr:
+    with rserv.ReplicationServer(url, "osc.gz") as svr:
         log.info("Using replication service at %s", url)
+
+        svr.set_request_parameter('timeout', options.socket_timeout or None)
+
+        if options.cookie is not None:
+            cookie_jar = http.cookiejar.MozillaCookieJar(options.cookie)
+            cookie_jar.load(options.cookie)
+            svr.set_request_parameter('cookies', cookie_jar)
 
         current = svr.get_state_info()
         if current is None:

--- a/tools/pyosmium-up-to-date
+++ b/tools/pyosmium-up-to-date
@@ -35,7 +35,6 @@ import re
 import sys
 import traceback
 import logging
-import socket
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import datetime as dt
@@ -70,7 +69,10 @@ def update_from_osm_server(ts, options):
 
 def update_from_custom_server(url, seq, ts, options):
     """Update from a custom URL, simply using the diff sequence as is."""
-    with rserv.ReplicationServer(url, "osc.gz") as svr:
+    extra_request_params = dict(stream=True,
+                                timeout=options.socket_timeout or None)
+
+    with rserv.ReplicationServer(url, "osc.gz", extra_request_params=extra_request_params) as svr:
         if options.cookie is not None:
             # According to the documentation, the cookie jar loads the file only if FileCookieJar.load is called.
             cookie_jar = cookiejarlib.MozillaCookieJar(options.cookie)
@@ -243,8 +245,6 @@ if __name__ == '__main__':
 
     options = get_arg_parser(from_main=True).parse_args()
     log.setLevel(max(3 - options.loglevel, 0) * 10)
-
-    socket.setdefaulttimeout(options.socket_timeout)
 
     try:
         url, seq, ts = compute_start_point(options)

--- a/tools/pyosmium-up-to-date
+++ b/tools/pyosmium-up-to-date
@@ -35,6 +35,7 @@ import re
 import sys
 import traceback
 import logging
+import http.cookiejar
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import datetime as dt
@@ -45,15 +46,6 @@ from osmium.version import pyosmium_release
 from textwrap import dedent as msgfmt
 from tempfile import mktemp
 import os.path
-
-try:
-    import http.cookiejar as cookiejarlib
-except ImportError:
-    import cookielib as cookiejarlib
-try:
-    import urllib.request as urlrequest
-except ImportError:
-    import urllib2 as urlrequest
 
 log = logging.getLogger()
 
@@ -72,14 +64,12 @@ def update_from_custom_server(url, seq, ts, options):
     extra_request_params = dict(stream=True,
                                 timeout=options.socket_timeout or None)
 
-    with rserv.ReplicationServer(url, "osc.gz", extra_request_params=extra_request_params) as svr:
-        if options.cookie is not None:
-            # According to the documentation, the cookie jar loads the file only if FileCookieJar.load is called.
-            cookie_jar = cookiejarlib.MozillaCookieJar(options.cookie)
-            cookie_jar.load(options.cookie)
-            opener = urlrequest.build_opener(urlrequest.HTTPCookieProcessor(cookie_jar))
-            svr.open_url = opener.open
+    if options.cookie is not None:
+        cookie_jar = http.cookiejar.MozillaCookieJar(options.cookie)
+        cookie_jar.load(options.cookie)
+        extra_request_params['cookies'] = cookie_jar
 
+    with rserv.ReplicationServer(url, "osc.gz", extra_request_params=extra_request_params) as svr:
         log.info("Using replication service at %s", url)
 
         current = svr.get_state_info()


### PR DESCRIPTION
The requests library seems to ignore socket timeouts with the result that newer versions of the pyosmium tools may hang again on a bad network connection. There is no global parameter to set timeouts in requests, so the whole code needs to be rearranged a bit.

`ReplicationServer` now has an extra function `set_request_parameter()` with which extra parameters for `requests.get()` can be set. This is not only used for timeouts but also to hand in the cookies.

Overwriting the `open_url()` function should no longer be necessary. You can set proxies, authentication, certificates etc. all with the new function.