### PR TITLE
Generalize osmium.apply() to work with an arbitrary number of handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,13 @@ jobs:
         runs-on: ubuntu-20.04
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Install packages
               run: sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev liblz4-dev
 
             - name: Set up Python 3.6
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.6
 
@@ -24,7 +24,7 @@ jobs:
               shell: bash
 
             - name: Set up Python 3.7
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.7
 
@@ -35,7 +35,7 @@ jobs:
               shell: bash
 
             - name: Set up Python 3.8
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.8
 
@@ -46,7 +46,7 @@ jobs:
               shell: bash
 
             - name: Set up Python 3.9
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.9
 
@@ -57,7 +57,7 @@ jobs:
               shell: bash
 
             - name: Set up Python 3.10
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: "3.10"
 
@@ -68,7 +68,7 @@ jobs:
               shell: bash
 
             - name: Set up Python 3.11
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: "3.11"
 
@@ -79,7 +79,7 @@ jobs:
               shell: bash
 
             - name: Set up Python 3.12
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: "3.12"
 
@@ -105,10 +105,10 @@ jobs:
                 python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -167,13 +167,13 @@ jobs:
             CXX: ${{ matrix.cxx }}
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - uses: ./.github/actions/install-dependencies
               with:
                   version: ${{ matrix.deps }}
 
-            - uses: actions/setup-python@v4
+            - uses: actions/setup-python@v5
               with:
                   python-version: "${{ matrix.python }}"
 
@@ -212,7 +212,7 @@ jobs:
             VCPKG_DEFAULT_BINARY_CACHE: C:/vcpkg_binary_cache
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - uses: actions/cache@v3
               with:
@@ -229,7 +229,7 @@ jobs:
               shell: bash
 
             - name: Set up Python 3.6
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.6
 
@@ -242,7 +242,7 @@ jobs:
                   CMAKE_TOOLCHAIN_FILE: C:/vcpkg/scripts/buildsystems/vcpkg.cmake
 
             - name: Set up Python 3.7
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.7
 
@@ -255,7 +255,7 @@ jobs:
                   CMAKE_TOOLCHAIN_FILE: C:/vcpkg/scripts/buildsystems/vcpkg.cmake
 
             - name: Set up Python 3.8
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.8
 
@@ -268,7 +268,7 @@ jobs:
                   CMAKE_TOOLCHAIN_FILE: C:/vcpkg/scripts/buildsystems/vcpkg.cmake
 
             - name: Set up Python 3.9
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: 3.9
 
@@ -281,7 +281,7 @@ jobs:
                   CMAKE_TOOLCHAIN_FILE: C:/vcpkg/scripts/buildsystems/vcpkg.cmake
 
             - name: Set up Python 3.10
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: "3.10"
 
@@ -294,7 +294,7 @@ jobs:
                   CMAKE_TOOLCHAIN_FILE: C:/vcpkg/scripts/buildsystems/vcpkg.cmake
 
             - name: Set up Python 3.11
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: "3.11"
 
@@ -325,10 +325,10 @@ jobs:
             PYTEST_ADDOPTS: ${{ matrix.test-args }}
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ set_module_output(_osm osmium/osm)
 pybind11_add_module(_osmium
                     lib/osmium.cc
                     lib/merge_input_reader.cc
+                    lib/node_location_handler.cc
                     lib/simple_writer.cc
                     lib/write_handler.cc)
 set_module_output(_osmium osmium)

--- a/lib/base_handler.h
+++ b/lib/base_handler.h
@@ -8,32 +8,12 @@
 #ifndef PYOSMIUM_BASE_HANDLER_HPP
 #define PYOSMIUM_BASE_HANDLER_HPP
 
-#include <osmium/area/assembler.hpp>
-#include <osmium/area/multipolygon_manager.hpp>
 #include <osmium/handler.hpp>
-#include <osmium/handler/node_locations_for_ways.hpp>
-#include <osmium/index/map/all.hpp>
 
 class BaseHandler : public osmium::handler::Handler
 {
-    using IndexType =
-        osmium::index::map::Map<osmium::unsigned_object_id_type, osmium::Location>;
-    using IndexFactory =
-        osmium::index::MapFactory<osmium::unsigned_object_id_type, osmium::Location>;
-    using MpManager =
-        osmium::area::MultipolygonManager<osmium::area::Assembler>;
-
-
-protected:
-    enum pre_handler {
-        no_handler,
-        location_handler,
-        area_handler
-    };
-
 public:
     virtual ~BaseHandler() = default;
-    virtual osmium::osm_entity_bits::type enabled_callbacks() = 0;
 
     // work around pybind's bad copy policy
     // (see https://github.com/pybind/pybind11/issues/1241)
@@ -49,66 +29,6 @@ public:
     virtual void relation(const osmium::Relation*) {}
     virtual void changeset(const osmium::Changeset*) {}
     virtual void area(const osmium::Area*) {}
-
-
-private:
-    void apply_with_location(osmium::io::Reader &r, const std::string &idx)
-    {
-        const auto &map_factory = IndexFactory::instance();
-        auto index = map_factory.create_map(idx);
-        osmium::handler::NodeLocationsForWays<IndexType> location_handler(*index);
-        location_handler.ignore_errors();
-
-        osmium::apply(r, location_handler, *this);
-    }
-
-    void apply_with_area(osmium::io::Reader &r, MpManager &mp_manager,
-                         const std::string &idx)
-    {
-        const auto &map_factory = IndexFactory::instance();
-        auto index = map_factory.create_map(idx);
-        osmium::handler::NodeLocationsForWays<IndexType> location_handler(*index);
-        location_handler.ignore_errors();
-
-        osmium::apply(r, location_handler, *this,
-                      mp_manager.handler([this](const osmium::memory::Buffer &ab)
-                                         { osmium::apply(ab, *this); }));
-    }
-
-protected:
-    void apply(const osmium::io::File &file, osmium::osm_entity_bits::type types,
-               pre_handler pre = no_handler,
-               const std::string &idx = "flex_mem")
-    {
-         switch (pre) {
-            case no_handler:
-                {
-                    osmium::io::Reader reader(file, types);
-                    osmium::apply(reader, *this);
-                    reader.close();
-                    break;
-                }
-            case location_handler:
-                {
-                    osmium::io::Reader reader(file, types);
-                    apply_with_location(reader, idx);
-                    reader.close();
-                    break;
-                }
-            case area_handler:
-                {
-                    osmium::area::Assembler::config_type assembler_config;
-                    MpManager mp_manager{assembler_config};
-
-                    osmium::relations::read_relations(file, mp_manager);
-
-                    osmium::io::Reader reader2(file);
-                    apply_with_area(reader2, mp_manager, idx);
-                    reader2.close();
-                    break;
-                }
-        }
-    }
 
 };
 

--- a/lib/base_handler.h
+++ b/lib/base_handler.h
@@ -2,7 +2,7 @@
  *
  * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
  *
- * Copyright (C) 2023 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
  * For a full list of authors see the git log.
  */
 #ifndef PYOSMIUM_BASE_HANDLER_HPP
@@ -18,14 +18,14 @@ public:
     // work around pybind's bad copy policy
     // (see https://github.com/pybind/pybind11/issues/1241)
     void node(const osmium::Node &o) { node(&o); }
-    void way(const osmium::Way &o) { way(&o); }
+    void way(osmium::Way &o) { way(&o); }
     void relation(const osmium::Relation &o) { relation(&o); }
     void changeset(const osmium::Changeset &o) { changeset(&o); }
     void area(const osmium::Area &o) { area(&o); }
 
     // actual handler functions
     virtual void node(const osmium::Node*) {}
-    virtual void way(const osmium::Way*) {}
+    virtual void way(osmium::Way *) {}
     virtual void relation(const osmium::Relation*) {}
     virtual void changeset(const osmium::Changeset*) {}
     virtual void area(const osmium::Area*) {}

--- a/lib/merge_input_reader.cc
+++ b/lib/merge_input_reader.cc
@@ -2,7 +2,7 @@
  *
  * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
  *
- * Copyright (C) 2023 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
  * For a full list of authors see the git log.
  */
 #include <pybind11/pybind11.h>
@@ -133,7 +133,7 @@ private:
             objects.sort(osmium::object_order_type_id_reverse_version());
             osmium::item_type prev_type = osmium::item_type::undefined;
             osmium::object_id_type prev_id = 0;
-            for (const auto &item: objects) {
+            for (auto &item: objects) {
                 if (item.type() != prev_type || item.id() != prev_id) {
                     prev_type = item.type();
                     prev_id = item.id();
@@ -142,7 +142,7 @@ private:
             }
         } else {
             objects.sort(osmium::object_order_type_id_version());
-            osmium::apply(objects.cbegin(), objects.cend(), handler);
+            osmium::apply(objects.begin(), objects.end(), handler);
         }
 
         objects = osmium::ObjectPointerCollection();

--- a/lib/node_location_handler.cc
+++ b/lib/node_location_handler.cc
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
+ *
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * For a full list of authors see the git log.
+ */
+#include <pybind11/pybind11.h>
+
+#include <osmium/index/map/all.hpp>
+#include <osmium/handler/node_locations_for_ways.hpp>
+
+#include "base_handler.h"
+
+using LocationTable =
+        osmium::index::map::Map<osmium::unsigned_object_id_type, osmium::Location>;
+using NodeLocationHandler =
+        osmium::handler::NodeLocationsForWays<LocationTable>;
+
+
+class NodeLocationsForWays : public BaseHandler
+{
+public:
+    NodeLocationsForWays(LocationTable &idx)
+    : handler(idx)
+    {}
+
+    void node(const osmium::Node *o) override
+    {
+        handler.node(*o);
+    }
+
+    void way(osmium::Way *o) override
+    {
+        if (apply_nodes_to_ways) {
+            handler.way(*o);
+        }
+    }
+
+    bool get_apply_nodes_to_ways() const { return apply_nodes_to_ways; }
+
+    void set_apply_nodes_to_ways(bool val) { apply_nodes_to_ways = val; }
+
+    void ignore_errors() { handler.ignore_errors(); }
+
+private:
+    NodeLocationHandler handler;
+    bool apply_nodes_to_ways = true;
+};
+
+namespace py = pybind11;
+
+void init_node_location_handler(py::module &m)
+{
+    py::class_<NodeLocationsForWays, BaseHandler>(m, "NodeLocationsForWays")
+        .def(py::init<LocationTable&>(), py::keep_alive<1, 2>())
+        .def("ignore_errors", &NodeLocationsForWays::ignore_errors)
+        .def_property("apply_nodes_to_ways",
+                     &NodeLocationsForWays::get_apply_nodes_to_ways,
+                     &NodeLocationsForWays::set_apply_nodes_to_ways,
+                     "When set to false, locations are only collected "
+                     "and not automatically applied to way nodes.")
+    ;
+
+}

--- a/lib/osmium.cc
+++ b/lib/osmium.cc
@@ -5,14 +5,73 @@
  * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
  * For a full list of authors see the git log.
  */
+#include <vector>
+
 #include <pybind11/pybind11.h>
 
 #include <osmium/osm.hpp>
+#include <osmium/handler.hpp>
 
 #include "simple_handler.h"
 #include "osmium_module.h"
 
 namespace py = pybind11;
+
+class HandlerChain : public osmium::handler::Handler
+{
+public:
+    HandlerChain(std::vector<BaseHandler *> &&handlers)
+    : m_handlers(handlers)
+    {}
+
+    void node(osmium::Node const &o) {
+        for (auto const &handler : m_handlers) {
+            handler->node(&o);
+        }
+    }
+
+    void way(osmium::Way &w) {
+        for (auto const &handler : m_handlers) {
+            handler->way(&w);
+        }
+    }
+
+    void relation(osmium::Relation const &o) {
+        for (auto const &handler : m_handlers) {
+            handler->relation(&o);
+        }
+    }
+
+    void changeset(osmium::Changeset const &o) {
+        for (auto const &handler : m_handlers) {
+            handler->changeset(&o);
+        }
+    }
+
+    void area(osmium::Area const &o) {
+        for (auto const &handler : m_handlers) {
+            handler->area(&o);
+        }
+    }
+
+private:
+    std::vector<BaseHandler *> m_handlers;
+};
+
+
+static HandlerChain make_handler_chain(py::args args)
+{
+    std::vector<BaseHandler *> handlers;
+    for (auto const &arg: args) {
+        if (py::isinstance<BaseHandler>(arg)) {
+            handlers.push_back(arg.cast<BaseHandler *>());
+        } else {
+            throw py::type_error{"Argument must be a handler-like object."};
+        }
+    }
+
+    return HandlerChain(std::move(handlers));
+}
 
 PYBIND11_MODULE(_osmium, m) {
     py::register_exception<osmium::invalid_location>(m, "InvalidLocationError");
@@ -27,10 +86,16 @@ PYBIND11_MODULE(_osmium, m) {
     m.def("apply", [](osmium::io::Reader &rd, BaseHandler &h)
                    { py::gil_scoped_release release; osmium::apply(rd, h); },
           py::arg("reader"), py::arg("handler"),
-          "Apply a chain of handlers.");
-    m.def("apply", [](osmium::io::Reader &rd, BaseHandler &b1, BaseHandler &b2)
-                     { py::gil_scoped_release release; osmium::apply(rd, b1, b2); },
-          py::arg("reader"), py::arg("handler1"), py::arg("handler2"),
+          "Apply a single handler.");
+    m.def("apply", [](osmium::io::Reader &rd, py::args args)
+                     {
+                         auto handler = make_handler_chain(args);
+                         {
+                             py::gil_scoped_release release;
+                             osmium::apply(rd, handler);
+                         }
+                     },
+          py::arg("reader"),
           "Apply a chain of handlers.");
 
     py::class_<BaseHandler>(m, "BaseHandler");

--- a/lib/osmium_module.h
+++ b/lib/osmium_module.h
@@ -2,7 +2,7 @@
  *
  * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
  *
- * Copyright (C) 2023 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
  * For a full list of authors see the git log.
  */
 #ifndef PYOSMIUM_OSMIUM_MODULE_H
@@ -13,5 +13,6 @@
 void init_merge_input_reader(pybind11::module &m);
 void init_write_handler(pybind11::module &m);
 void init_simple_writer(pybind11::module &m);
+void init_node_location_handler(pybind11::module &m);
 
 #endif // PYOSMIUM_OSMIUM_MODULE_H

--- a/lib/simple_handler.h
+++ b/lib/simple_handler.h
@@ -13,14 +13,36 @@
 #include <osmium/io/any_input.hpp>
 #include <osmium/io/file.hpp>
 #include <osmium/visitor.hpp>
+#include <osmium/area/assembler.hpp>
+#include <osmium/area/multipolygon_manager.hpp>
+#include <osmium/handler/node_locations_for_ways.hpp>
+#include <osmium/index/map/all.hpp>
+
 
 #include "base_handler.h"
 #include "osm_base_objects.h"
 
 class SimpleHandler: public BaseHandler
 {
+    using IndexType =
+        osmium::index::map::Map<osmium::unsigned_object_id_type, osmium::Location>;
+    using IndexFactory =
+        osmium::index::MapFactory<osmium::unsigned_object_id_type, osmium::Location>;
+    using MpManager =
+        osmium::area::MultipolygonManager<osmium::area::Assembler>;
+
+
+protected:
+    enum pre_handler {
+        no_handler,
+        location_handler,
+        area_handler
+    };
+
+
 public:
     virtual ~SimpleHandler() = default;
+    virtual osmium::osm_entity_bits::type enabled_callbacks() = 0;
 
     void apply_file(pybind11::object filename, bool locations = false,
                     const std::string &idx = "flex_mem")
@@ -49,16 +71,14 @@ private:
     void apply_object(osmium::io::File file, bool locations, const std::string &idx)
     {
         osmium::osm_entity_bits::type entities = osmium::osm_entity_bits::nothing;
-        BaseHandler::pre_handler handler = locations?
-                                            BaseHandler::location_handler
-                                            :BaseHandler::no_handler;
+        pre_handler handler = locations? location_handler : no_handler;
 
         auto callbacks = enabled_callbacks();
 
         if (callbacks & osmium::osm_entity_bits::area)
         {
             entities = osmium::osm_entity_bits::object;
-            handler = BaseHandler::area_handler;
+            handler = area_handler;
         } else {
             if (locations || callbacks & osmium::osm_entity_bits::node)
                 entities |= osmium::osm_entity_bits::node;
@@ -73,6 +93,64 @@ private:
 
         pybind11::gil_scoped_release release;
         apply(file, entities, handler, idx);
+    }
+
+
+    void apply_with_location(osmium::io::Reader &r, const std::string &idx)
+    {
+        const auto &map_factory = IndexFactory::instance();
+        auto index = map_factory.create_map(idx);
+        osmium::handler::NodeLocationsForWays<IndexType> location_handler(*index);
+        location_handler.ignore_errors();
+
+        osmium::apply(r, location_handler, *this);
+    }
+
+    void apply_with_area(osmium::io::Reader &r, MpManager &mp_manager,
+                         const std::string &idx)
+    {
+        const auto &map_factory = IndexFactory::instance();
+        auto index = map_factory.create_map(idx);
+        osmium::handler::NodeLocationsForWays<IndexType> location_handler(*index);
+        location_handler.ignore_errors();
+
+        osmium::apply(r, location_handler, *this,
+                      mp_manager.handler([this](const osmium::memory::Buffer &ab)
+                                         { osmium::apply(ab, *this); }));
+    }
+
+    void apply(const osmium::io::File &file, osmium::osm_entity_bits::type types,
+               pre_handler pre = no_handler,
+               const std::string &idx = "flex_mem")
+    {
+         switch (pre) {
+            case no_handler:
+                {
+                    osmium::io::Reader reader(file, types);
+                    osmium::apply(reader, *this);
+                    reader.close();
+                    break;
+                }
+            case location_handler:
+                {
+                    osmium::io::Reader reader(file, types);
+                    apply_with_location(reader, idx);
+                    reader.close();
+                    break;
+                }
+            case area_handler:
+                {
+                    osmium::area::Assembler::config_type assembler_config;
+                    MpManager mp_manager{assembler_config};
+
+                    osmium::relations::read_relations(file, mp_manager);
+
+                    osmium::io::Reader reader2(file);
+                    apply_with_area(reader2, mp_manager, idx);
+                    reader2.close();
+                    break;
+                }
+        }
     }
 };
 

--- a/lib/simple_handler.h
+++ b/lib/simple_handler.h
@@ -2,7 +2,7 @@
  *
  * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
  *
- * Copyright (C) 2023 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
  * For a full list of authors see the git log.
  */
 #ifndef PYOSMIUM_SIMPLE_HANDLER_HPP
@@ -115,7 +115,7 @@ private:
         location_handler.ignore_errors();
 
         osmium::apply(r, location_handler, *this,
-                      mp_manager.handler([this](const osmium::memory::Buffer &ab)
+                      mp_manager.handler([this](osmium::memory::Buffer &&ab)
                                          { osmium::apply(ab, *this); }));
     }
 
@@ -203,7 +203,7 @@ public:
         }
     }
 
-    void way(osmium::Way const *w) override
+    void way(osmium::Way *w) override
     {
         pybind11::gil_scoped_acquire acquire;
         auto func = callback("way");

--- a/lib/write_handler.cc
+++ b/lib/write_handler.cc
@@ -2,7 +2,7 @@
  *
  * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
  *
- * Copyright (C) 2023 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
  * For a full list of authors see the git log.
  */
 #include <pybind11/pybind11.h>
@@ -42,7 +42,7 @@ public:
         flush_buffer();
     }
 
-    void way(const osmium::Way* o) override
+    void way(osmium::Way* o) override
     {
         buffer.add_item(*o);
         flush_buffer();

--- a/lib/write_handler.cc
+++ b/lib/write_handler.cc
@@ -36,9 +36,6 @@ public:
     virtual ~WriteHandler()
     { close(); }
 
-    osmium::osm_entity_bits::type enabled_callbacks() override
-    { return osmium::osm_entity_bits::all; }
-
     void node(const osmium::Node* o) override
     {
         buffer.add_item(*o);

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,6 +52,14 @@ def test_data(tmp_path, to_opl):
 
     return _mkfile
 
+@pytest.fixture
+def opl_reader(test_data):
+
+    def _mkbuffer(data):
+        return o.io.Reader(test_data(data))
+
+    return _mkbuffer
+
 
 @pytest.fixture
 def simple_handler(to_opl):

--- a/test/test_osmium.py
+++ b/test/test_osmium.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: BSD
+#
+# This file is part of Pyosmium.
+#
+# Copyright (C) 2024 Sarah Hoffmann.
+import pytest
+import osmium as o
+
+
+def test_read_node_location_with_handler(opl_reader):
+    idx = o.index.create_map("flex_mem")
+    hdlr = o.NodeLocationsForWays(idx)
+
+    data = """\
+           n1 x6 y7
+           n45 x-3 y0
+           """
+
+    o.apply(opl_reader(data), hdlr)
+
+    assert idx.get(1).lon == pytest.approx(6)
+    assert idx.get(1).lat == pytest.approx(7)
+    assert idx.get(45).lon == pytest.approx(-3)
+    assert idx.get(45).lat == 0.0
+
+    with pytest.raises(KeyError):
+        idx.get(2)
+
+
+@pytest.mark.parametrize('ignore_error', [(True, False)])
+def test_apply_node_location_handler(opl_reader, ignore_error):
+
+    hdlr = o.NodeLocationsForWays(o.index.create_map("flex_mem"))
+    if ignore_error:
+        hdlr.ignore_errors()
+
+    class WayNodeHandler(o.SimpleHandler):
+        def __init__(self):
+            super().__init__()
+            self.collect = []
+            self.with_error = []
+
+        def way(self, w):
+            try:
+                self.collect.append((w.id, [(n.lon, n.lat) for n in w.nodes]))
+            except o.InvalidLocationError:
+                self.with_error.append(w.id)
+
+
+    data = """\
+           n1 x6 y7
+           n2 x6 y7.1
+           n45 x-3 y0
+           n55 x-2.9 y0
+           w3 Nn1,n2
+           w4 Nn45,n55,n56
+           """
+
+    tester = WayNodeHandler()
+
+    if ignore_error:
+        o.apply(opl_reader(data), hdlr, tester)
+
+        assert tester.collect == [(3, [(pytest.approx(6), pytest.approx(7)),
+                                      (pytest.approx(6), pytest.approx(7.1))])]
+        assert tester.with_error == [4]
+    else:
+        with pytest.raises(osmium.InvalidLocationError):
+            o.apply(opl.reader(data), hdlr, tester)


### PR DESCRIPTION
Reworks the apply() function to use an indirect handler that can handle a vector of BaseHandlers. This way, an arbitrary number of handlers can be chained in one apply.

NodeLocationForWays is now exposed through a wrapper class which also inherits from BaseHandler. This means we can get rid of the special treatment in apply(). The interface doesn't change except that there is a new functionality to switch off applying node locations to ways.call to 