### PR TITLE
Allow any Python object to be used as a handler object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
               shell: bash
 
             - name: Upload Artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: pyosmium-linux-x64-dist
                   path: dist
@@ -112,7 +112,7 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: pyosmium-linux-x64-dist
 
@@ -307,7 +307,7 @@ jobs:
                   CMAKE_TOOLCHAIN_FILE: C:/vcpkg/scripts/buildsystems/vcpkg.cmake
 
             - name: 'Upload Artifact'
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: pyosmium-win64-dist
                   path: dist
@@ -332,7 +332,7 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
 
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                   name: pyosmium-win64-dist
 

--- a/lib/python_handler.h
+++ b/lib/python_handler.h
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
+ *
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * For a full list of authors see the git log.
+ */
+#ifndef PYOSMIUM_PYTHON_HANDLER_HPP
+#define PYOSMIUM_PYTHON_HANDLER_HPP
+
+#include <pybind11/pybind11.h>
+
+#include "base_handler.h"
+
+namespace pyosmium {
+
+template <typename T>
+class ObjectGuard {
+    using WardPtr = T*;
+
+    public:
+        ObjectGuard(pybind11::object ward) : m_ward(ward) {}
+
+        ~ObjectGuard() {
+            m_ward.attr("_pyosmium_data").template cast<WardPtr>()->invalidate();
+        }
+
+    private:
+        pybind11::object m_ward;
+};
+
+
+class PythonHandler : public BaseHandler
+{
+public:
+    PythonHandler(pybind11::handle handler)
+    : m_handler(std::move(handler))
+    {}
+
+    void node(osmium::Node const *n) override
+    {
+        pybind11::gil_scoped_acquire acquire;
+        if (pybind11::hasattr(m_handler, "node")) {
+            auto obj = m_type_module.attr("Node")(COSMNode{n});
+            ObjectGuard<COSMNode> guard(obj);
+            m_handler.attr("node")(obj);
+        }
+    }
+
+    void way(osmium::Way *w) override
+    {
+        pybind11::gil_scoped_acquire acquire;
+        if (pybind11::hasattr(m_handler, "way")) {
+            auto obj = m_type_module.attr("Way")(COSMWay{w});
+            ObjectGuard<COSMWay> guard(obj);
+            m_handler.attr("way")(obj);
+        }
+    }
+
+    void relation(osmium::Relation const *r) override
+    {
+        pybind11::gil_scoped_acquire acquire;
+        if (pybind11::hasattr(m_handler, "relation")) {
+            auto obj = m_type_module.attr("Relation")(COSMRelation{r});
+            ObjectGuard<COSMRelation> guard(obj);
+            m_handler.attr("relation")(obj);
+        }
+    }
+
+    void changeset(osmium::Changeset const *c) override
+    {
+        pybind11::gil_scoped_acquire acquire;
+        if (pybind11::hasattr(m_handler, "changeset")) {
+            auto obj = m_type_module.attr("Changeset")(COSMChangeset{c});
+            ObjectGuard<COSMChangeset> guard(obj);
+            m_handler.attr("changeset")(obj);
+        }
+    }
+
+    void area(osmium::Area const *a) override
+    {
+        pybind11::gil_scoped_acquire acquire;
+        if (pybind11::hasattr(m_handler, "area")) {
+            auto obj = m_type_module.attr("Area")(COSMArea{a});
+            ObjectGuard<COSMArea> guard(obj);
+            m_handler.attr("area")(obj);
+        }
+    }
+private:
+    pybind11::object m_type_module = pybind11::module_::import("osmium.osm.types");
+    pybind11::handle m_handler;
+};
+
+} // namespace
+
+#endif //PYOSMIUM_PYTHON_HANDLER_HPP
+

--- a/test/test_osmium.py
+++ b/test/test_osmium.py
@@ -34,9 +34,8 @@ def test_apply_node_location_handler(opl_reader, ignore_error):
     if ignore_error:
         hdlr.ignore_errors()
 
-    class WayNodeHandler(o.SimpleHandler):
+    class WayNodeHandler:
         def __init__(self):
-            super().__init__()
             self.collect = []
             self.with_error = []
 
@@ -67,3 +66,28 @@ def test_apply_node_location_handler(opl_reader, ignore_error):
     else:
         with pytest.raises(osmium.InvalidLocationError):
             o.apply(opl.reader(data), hdlr, tester)
+
+
+def test_apply_invalid_handler_object(opl_reader):
+    class DummyHandler:
+        def some_func():
+            print('A')
+
+    with pytest.raises(TypeError):
+        o.apply(opl_reader("n1 x2 z4"), DummyHandler())
+
+
+def test_mixed_handlers(opl_reader):
+    logged = []
+
+    class OldStyle(o.SimpleHandler):
+        def node(self, n):
+            logged.append('old')
+
+    class NewStyle:
+        def node(self, n):
+            logged.append('new')
+
+    o.apply(opl_reader("n1 x0 y0"), NewStyle(), OldStyle(), NewStyle(), OldStyle())
+
+    assert logged == ['new', 'old', 'new', 'old']


### PR DESCRIPTION
Switch to duck-typing for handlers. Any Python object which implements any of the functions `node()`, `way()`, `relation()`, `area()`, `changeset()` will be accepted as a handler in the `osmium.apply()` function.