### PR TITLE
Introduce filter handlers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,15 @@ pybind11_add_module(_replication lib/replication.cc)
 set_module_output(_replication osmium/replication)
 pybind11_add_module(_area lib/area.cc)
 set_module_output(_area osmium/area)
-
+pybind11_add_module(_filter
+                    lib/filter.cc
+                    lib/empty_tag_filter.cc)
+set_module_output(_filter osmium/filter)
 
 target_link_libraries(_osmium PRIVATE ${OSMIUM_LIBRARIES})
 target_link_libraries(_replication PRIVATE ${OSMIUM_LIBRARIES})
 target_link_libraries(_area PRIVATE ${OSMIUM_LIBRARIES})
+target_link_libraries(_filter PRIVATE ${OSMIUM_LIBRARIES})
 
 # workaround for https://github.com/pybind/pybind11/issues/1272
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,8 @@ pybind11_add_module(_area lib/area.cc)
 set_module_output(_area osmium/area)
 pybind11_add_module(_filter
                     lib/filter.cc
-                    lib/empty_tag_filter.cc)
+                    lib/empty_tag_filter.cc
+                    lib/key_filter.cc)
 set_module_output(_filter osmium/filter)
 
 target_link_libraries(_osmium PRIVATE ${OSMIUM_LIBRARIES})

--- a/examples/amenity_list.py
+++ b/examples/amenity_list.py
@@ -18,22 +18,20 @@ class AmenityListHandler(o.SimpleHandler):
         print("%f %f %-15s %s" % (lon, lat, tags['amenity'], name))
 
     def node(self, n):
-        if 'amenity' in n.tags:
-            self.print_amenity(n.tags, n.location.lon, n.location.lat)
+        self.print_amenity(n.tags, n.location.lon, n.location.lat)
 
     def area(self, a):
-        if 'amenity' in a.tags:
-            wkb = wkbfab.create_multipolygon(a)
-            poly = wkblib.loads(wkb, hex=True)
-            centroid = poly.representative_point()
-            self.print_amenity(a.tags, centroid.x, centroid.y)
+        wkb = wkbfab.create_multipolygon(a)
+        poly = wkblib.loads(wkb, hex=True)
+        centroid = poly.representative_point()
+        self.print_amenity(a.tags, centroid.x, centroid.y)
 
 
 def main(osmfile):
 
     handler = AmenityListHandler()
 
-    handler.apply_file(osmfile)
+    handler.apply_file(osmfile, filters=[o.filter.KeyFilter('amenity')])
 
     return 0
 

--- a/lib/area.cc
+++ b/lib/area.cc
@@ -30,19 +30,22 @@ public:
                                           { osmium::apply(ab, this->m_handlers); });
     }
 
-    void node(osmium::Node const *n) override
+    bool node(osmium::Node const *n) override
     {
         m_mp_manager->handle_node(*n);
+        return false;
     }
 
-    void way(osmium::Way *w) override
+    bool way(osmium::Way *w) override
     {
         m_mp_manager->handle_way(*w);
+        return false;
     }
 
-    void relation(osmium::Relation const *r) override
+    bool relation(osmium::Relation const *r) override
     {
         m_mp_manager->handle_relation(*r);
+        return false;
     }
 
     void flush() override
@@ -67,9 +70,10 @@ public:
     BaseHandler *first_pass_handler() { return this; }
 
     // first-pass-handler
-    void relation(osmium::Relation const *r) override
+    bool relation(osmium::Relation const *r) override
     {
         m_mp_manager.relation(*r);
+        return false;
     }
 
     AreaManagerSecondPassHandler *second_pass_handler(py::args args)

--- a/lib/base_filter.h
+++ b/lib/base_filter.h
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
+ *
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * For a full list of authors see the git log.
+ */
+#ifndef PYOSMIUM_BASE_FILTER_HPP
+#define PYOSMIUM_BASE_FILTER_HPP
+
+#include <osmium/osm.hpp>
+#include <osmium/osm/entity_bits.hpp>
+
+#include "base_handler.h"
+
+namespace pyosmium {
+
+class BaseFilter : public BaseHandler {
+public:
+    bool node(osmium::Node const *n) override
+    {
+        return (m_enabled_for & osmium::osm_entity_bits::node)
+               && (filter_node(n) != m_inverted);
+    }
+
+    bool way(osmium::Way *n) override
+    {
+        return (m_enabled_for & osmium::osm_entity_bits::way)
+               && (filter_way(n) != m_inverted);
+    }
+
+    bool relation(osmium::Relation const *n) override
+    {
+        return (m_enabled_for & osmium::osm_entity_bits::relation)
+               && (filter_relation(n) != m_inverted);
+    }
+
+    bool area(osmium::Area const *n) override
+    {
+        return (m_enabled_for & osmium::osm_entity_bits::area)
+               && (filter_area(n) != m_inverted);
+    }
+
+    bool changeset(osmium::Changeset const *n) override
+    {
+        return (m_enabled_for & osmium::osm_entity_bits::changeset)
+               && (filter_changeset(n) != m_inverted);
+    }
+
+    BaseFilter *enable_for(osmium::osm_entity_bits::type entities)
+    {
+        m_enabled_for = entities;
+        return this;
+    }
+
+    BaseFilter *invert(bool new_state)
+    {
+        m_inverted = new_state;
+        return this;
+    }
+
+protected:
+    virtual bool filter(osmium::OSMObject const *) { return false; }
+    virtual bool filter_node(osmium::Node const *n) { return filter(n); }
+    virtual bool filter_way(osmium::Way const *w) { return filter(w); }
+    virtual bool filter_relation(osmium::Relation const *r) { return filter(r); }
+    virtual bool filter_area(osmium::Area const *a) { return filter(a); }
+    virtual bool filter_changeset(osmium::Changeset const *) { return false; }
+
+private:
+    bool m_inverted = false;
+    osmium::osm_entity_bits::type m_enabled_for = osmium::osm_entity_bits::all;
+
+};
+
+
+void init_empty_tag_filter(pybind11::module &m);
+
+} // namespace
+
+
+#endif //PYOSMIUM_BASE_FILTER_HPP

--- a/lib/base_filter.h
+++ b/lib/base_filter.h
@@ -75,6 +75,7 @@ private:
 
 
 void init_empty_tag_filter(pybind11::module &m);
+void init_key_filter(pybind11::module &m);
 
 } // namespace
 

--- a/lib/base_filter.h
+++ b/lib/base_filter.h
@@ -20,42 +20,36 @@ public:
     bool node(osmium::Node const *n) override
     {
         return (m_enabled_for & osmium::osm_entity_bits::node)
-               && (filter_node(n) != m_inverted);
+               && filter_node(n);
     }
 
     bool way(osmium::Way *n) override
     {
         return (m_enabled_for & osmium::osm_entity_bits::way)
-               && (filter_way(n) != m_inverted);
+               && filter_way(n);
     }
 
     bool relation(osmium::Relation const *n) override
     {
         return (m_enabled_for & osmium::osm_entity_bits::relation)
-               && (filter_relation(n) != m_inverted);
+               && filter_relation(n);
     }
 
     bool area(osmium::Area const *n) override
     {
         return (m_enabled_for & osmium::osm_entity_bits::area)
-               && (filter_area(n) != m_inverted);
+               && filter_area(n);
     }
 
     bool changeset(osmium::Changeset const *n) override
     {
         return (m_enabled_for & osmium::osm_entity_bits::changeset)
-               && (filter_changeset(n) != m_inverted);
+               && filter_changeset(n);
     }
 
     BaseFilter *enable_for(osmium::osm_entity_bits::type entities)
     {
         m_enabled_for = entities;
-        return this;
-    }
-
-    BaseFilter *invert(bool new_state)
-    {
-        m_inverted = new_state;
         return this;
     }
 
@@ -68,7 +62,6 @@ protected:
     virtual bool filter_changeset(osmium::Changeset const *) { return false; }
 
 private:
-    bool m_inverted = false;
     osmium::osm_entity_bits::type m_enabled_for = osmium::osm_entity_bits::all;
 
 };

--- a/lib/base_handler.h
+++ b/lib/base_handler.h
@@ -23,12 +23,15 @@ public:
     void changeset(const osmium::Changeset &o) { changeset(&o); }
     void area(const osmium::Area &o) { area(&o); }
 
-    // actual handler functions
-    virtual void node(const osmium::Node*) {}
-    virtual void way(osmium::Way *) {}
-    virtual void relation(const osmium::Relation*) {}
-    virtual void changeset(const osmium::Changeset*) {}
-    virtual void area(const osmium::Area*) {}
+    // Actual handler functions.
+    // All object handlers return a boolean which indicates if
+    // processing is finished (true) or should be continued with the next
+    // handler (false).
+    virtual bool node(const osmium::Node*) { return false; }
+    virtual bool way(osmium::Way *) { return false; }
+    virtual bool relation(const osmium::Relation*) { return false; }
+    virtual bool changeset(const osmium::Changeset*) { return false; }
+    virtual bool area(const osmium::Area*)  { return false; }
 
     virtual void flush() {}
 };

--- a/lib/empty_tag_filter.cc
+++ b/lib/empty_tag_filter.cc
@@ -21,6 +21,12 @@ class EmptyTagFilter : public pyosmium::BaseFilter
     {
         return o->tags().empty();
     }
+
+    bool filter_changeset(osmium::Changeset const *o) override
+    {
+        return o->tags().empty();
+    }
+
 };
 
 }

--- a/lib/empty_tag_filter.cc
+++ b/lib/empty_tag_filter.cc
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
+ *
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * For a full list of authors see the git log.
+ */
+#include <pybind11/pybind11.h>
+
+#include <osmium/osm.hpp>
+
+#include "base_filter.h"
+
+namespace py = pybind11;
+
+namespace {
+
+class EmptyTagFilter : public pyosmium::BaseFilter
+{
+    bool filter(osmium::OSMObject const *o) override
+    {
+        return o->tags().empty();
+    }
+};
+
+}
+
+namespace pyosmium {
+
+void init_empty_tag_filter(pybind11::module &m)
+{
+    py::class_<EmptyTagFilter, pyosmium::BaseFilter, BaseHandler>(m, "EmptyTagFilter")
+        .def(py::init<>())
+    ;
+}
+
+} // namespace

--- a/lib/filter.cc
+++ b/lib/filter.cc
@@ -17,8 +17,6 @@ PYBIND11_MODULE(_filter, m) {
         .def("enable_for", &pyosmium::BaseFilter::enable_for,
              py::arg("entities"),
              "Set the OSM types this filter should be used for.")
-        .def("invert", &pyosmium::BaseFilter::invert,
-             py::arg("new_state")=true)
     ;
 
     pyosmium::init_empty_tag_filter(m);

--- a/lib/filter.cc
+++ b/lib/filter.cc
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
+ *
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * For a full list of authors see the git log.
+ */
+#include <pybind11/pybind11.h>
+
+#include "base_filter.h"
+
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_filter, m) {
+    py::class_<pyosmium::BaseFilter, BaseHandler>(m, "BaseFilter")
+        .def("enable_for", &pyosmium::BaseFilter::enable_for,
+             py::arg("entities"),
+             "Set the OSM types this filter should be used for.")
+        .def("invert", &pyosmium::BaseFilter::invert,
+             py::arg("new_state")=true)
+    ;
+
+    pyosmium::init_empty_tag_filter(m);
+};
+

--- a/lib/filter.cc
+++ b/lib/filter.cc
@@ -22,5 +22,6 @@ PYBIND11_MODULE(_filter, m) {
     ;
 
     pyosmium::init_empty_tag_filter(m);
+    pyosmium::init_key_filter(m);
 };
 

--- a/lib/handler_chain.h
+++ b/lib/handler_chain.h
@@ -45,31 +45,41 @@ public:
 
     void node(osmium::Node const &o) {
         for (auto const &handler : m_handlers) {
-            handler->node(&o);
+            if (handler->node(&o)) {
+                return;
+            }
         }
     }
 
     void way(osmium::Way &w) {
         for (auto const &handler : m_handlers) {
-            handler->way(&w);
+            if (handler->way(&w)) {
+                return;
+            }
         }
     }
 
     void relation(osmium::Relation const &o) {
         for (auto const &handler : m_handlers) {
-            handler->relation(&o);
+            if (handler->relation(&o)) {
+                return;
+            }
         }
     }
 
     void changeset(osmium::Changeset const &o) {
         for (auto const &handler : m_handlers) {
-            handler->changeset(&o);
+            if (handler->changeset(&o)) {
+                return;
+            }
         }
     }
 
     void area(osmium::Area const &o) {
         for (auto const &handler : m_handlers) {
-            handler->area(&o);
+            if (handler->area(&o)) {
+                return;
+            }
         }
     }
 

--- a/lib/key_filter.cc
+++ b/lib/key_filter.cc
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * This file is part of pyosmium. (https://osmcode.org/pyosmium/)
+ *
+ * Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
+ * For a full list of authors see the git log.
+ */
+#include <pybind11/pybind11.h>
+
+#include <osmium/osm.hpp>
+
+#include "base_filter.h"
+
+namespace py = pybind11;
+
+namespace {
+
+class KeyFilter : public pyosmium::BaseFilter
+{
+public:
+    KeyFilter(py::args args)
+    {
+        if (args.empty()) {
+            throw py::type_error{"Need keys to filter on."};
+        }
+
+        m_keys.reserve(args.size());
+        for (auto const &arg: args) {
+            if (!py::isinstance<py::str>(arg)) {
+                throw py::type_error{"Arguments must be strings."};
+            }
+
+            m_keys.push_back(arg.cast<std::string>());
+        }
+    }
+
+    bool filter(osmium::OSMObject const *o) override
+    {
+        auto const &tags = o->tags();
+        for (auto const &key: m_keys) {
+            if (tags.has_key(key.c_str())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+private:
+    std::vector<std::string> m_keys;
+};
+
+}
+
+namespace pyosmium {
+
+void init_key_filter(pybind11::module &m)
+{
+    py::class_<KeyFilter, pyosmium::BaseFilter, BaseHandler>(m, "KeyFilter")
+        .def(py::init<py::args>())
+    ;
+}
+
+} // namespace

--- a/lib/key_filter.cc
+++ b/lib/key_filter.cc
@@ -46,6 +46,18 @@ public:
         return true;
     }
 
+    bool filter_changeset(osmium::Changeset const *o) override
+    {
+        auto const &tags = o->tags();
+        for (auto const &key: m_keys) {
+            if (tags.has_key(key.c_str())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
 private:
     std::vector<std::string> m_keys;
 };

--- a/lib/node_location_handler.cc
+++ b/lib/node_location_handler.cc
@@ -25,16 +25,18 @@ public:
     : handler(idx)
     {}
 
-    void node(const osmium::Node *o) override
+    bool node(const osmium::Node *o) override
     {
         handler.node(*o);
+        return false;
     }
 
-    void way(osmium::Way *o) override
+    bool way(osmium::Way *o) override
     {
         if (apply_nodes_to_ways) {
             handler.way(*o);
         }
+        return false;
     }
 
     bool get_apply_nodes_to_ways() const { return apply_nodes_to_ways; }

--- a/lib/osmium.cc
+++ b/lib/osmium.cc
@@ -45,6 +45,25 @@ PYBIND11_MODULE(_osmium, m) {
                      },
           py::arg("reader"),
           "Apply a chain of handlers.");
+    m.def("apply", [](std::string fn, BaseHandler &h)
+                   {
+                       py::gil_scoped_release release;
+                       osmium::io::Reader rd{fn};
+                       osmium::apply(rd, h);
+                   },
+          py::arg("filename"), py::arg("handler"),
+          "Apply a single handler.");
+    m.def("apply", [](std::string fn, py::args args)
+                     {
+                         HandlerChain handler{args};
+                         {
+                             py::gil_scoped_release release;
+                             osmium::io::Reader rd{fn};
+                             osmium::apply(rd, handler);
+                         }
+                     },
+          py::arg("filename"),
+          "Apply a chain of handlers.");
 
     py::class_<BaseHandler>(m, "BaseHandler");
 

--- a/lib/python_handler.h
+++ b/lib/python_handler.h
@@ -56,7 +56,7 @@ public:
     }
 
 
-    void node(osmium::Node const *n) override
+    bool node(osmium::Node const *n) override
     {
         if (m_enabled & osmium::osm_entity_bits::node) {
             pybind11::gil_scoped_acquire acquire;
@@ -64,9 +64,10 @@ public:
             ObjectGuard<COSMNode> guard(obj);
             m_handler.attr("node")(obj);
         }
+        return false;
     }
 
-    void way(osmium::Way *w) override
+    bool way(osmium::Way *w) override
     {
         if (m_enabled & osmium::osm_entity_bits::way) {
             pybind11::gil_scoped_acquire acquire;
@@ -74,9 +75,10 @@ public:
             ObjectGuard<COSMWay> guard(obj);
             m_handler.attr("way")(obj);
         }
+        return false;
     }
 
-    void relation(osmium::Relation const *r) override
+    bool relation(osmium::Relation const *r) override
     {
         if (m_enabled & osmium::osm_entity_bits::relation) {
             pybind11::gil_scoped_acquire acquire;
@@ -84,9 +86,10 @@ public:
             ObjectGuard<COSMRelation> guard(obj);
             m_handler.attr("relation")(obj);
         }
+        return false;
     }
 
-    void changeset(osmium::Changeset const *c) override
+    bool changeset(osmium::Changeset const *c) override
     {
         if (m_enabled & osmium::osm_entity_bits::changeset) {
             pybind11::gil_scoped_acquire acquire;
@@ -94,9 +97,10 @@ public:
             ObjectGuard<COSMChangeset> guard(obj);
             m_handler.attr("changeset")(obj);
         }
+        return false;
     }
 
-    void area(osmium::Area const *a) override
+    bool area(osmium::Area const *a) override
     {
         if (m_enabled & osmium::osm_entity_bits::area) {
             pybind11::gil_scoped_acquire acquire;
@@ -104,6 +108,7 @@ public:
             ObjectGuard<COSMArea> guard(obj);
             m_handler.attr("area")(obj);
         }
+        return false;
     }
 private:
     osmium::osm_entity_bits::type m_enabled;

--- a/lib/write_handler.cc
+++ b/lib/write_handler.cc
@@ -36,27 +36,31 @@ public:
     virtual ~WriteHandler()
     { close(); }
 
-    void node(const osmium::Node* o) override
+    bool node(const osmium::Node* o) override
     {
         buffer.add_item(*o);
         flush_buffer();
+        return false;
     }
 
-    void way(osmium::Way* o) override
+    bool way(osmium::Way* o) override
     {
         buffer.add_item(*o);
         flush_buffer();
+        return false;
     }
 
-    void relation(const osmium::Relation* o) override
+    bool relation(const osmium::Relation* o) override
     {
         buffer.add_item(*o);
         flush_buffer();
+        return false;
     }
 
-    void changeset(const osmium::Changeset*) override {}
-
-    void area(const osmium::Area*) override {}
+    void flush() override
+    {
+        flush_buffer(true);
+    }
 
     void close()
     {
@@ -68,11 +72,11 @@ public:
     }
 
 private:
-    void flush_buffer()
+    void flush_buffer(bool force = false)
     {
         buffer.commit();
 
-        if (buffer.committed() > buffer.capacity() - BUFFER_WRAP) {
+        if (force || buffer.committed() > buffer.capacity() - BUFFER_WRAP) {
             osmium::memory::Buffer new_buffer(buffer.capacity(), osmium::memory::Buffer::auto_grow::yes);
             using std::swap;
             swap(buffer, new_buffer);

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,8 @@ setup(
         ],
 
     ext_modules=[CMakeExtension('cmake_example')],
-    packages = ['osmium', 'osmium/osm', 'osmium/replication', 'osmium/area'],
+    packages = ['osmium', 'osmium/osm', 'osmium/replication', 'osmium/area',
+                'osmium/filter'],
     package_dir = {'' : 'src'},
     package_data = { 'osmium': ['py.typed', '*.pyi',
                                 'replication/_replication.pyi',

--- a/src/osmium/filter/__init__.py
+++ b/src/osmium/filter/__init__.py
@@ -4,13 +4,4 @@
 #
 # Copyright (C) 2024 Sarah Hoffmann <lonvia@denofr.de> and others.
 # For a full list of authors see the git log.
-
-from osmium._osmium import *
-from osmium.helper import *
-from osmium.simple_handler import SimpleHandler
-import osmium.io
-import osmium.osm
-import osmium.index
-import osmium.geom
-import osmium.area
-import osmium.filter
+from ._filter import *

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -24,3 +24,20 @@ class CountingHandler(osmium.SimpleHandler):
 
     def area(self, _):
         self.counts[3] += 1
+
+
+class IDCollector:
+
+    def __init__(self):
+        self.nodes = []
+        self.ways = []
+        self.relations = []
+
+    def node(self, n):
+        self.nodes.append(n.id)
+
+    def way(self, w):
+        self.ways.append(w.id)
+
+    def relation(self, r):
+        self.relations.append(r.id)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -32,6 +32,7 @@ class IDCollector:
         self.nodes = []
         self.ways = []
         self.relations = []
+        self.changesets = []
 
     def node(self, n):
         self.nodes.append(n.id)
@@ -41,3 +42,6 @@ class IDCollector:
 
     def relation(self, r):
         self.relations.append(r.id)
+
+    def changeset(self, c):
+        self.changesets.append(c.id)

--- a/test/test_empty_tag_filter.py
+++ b/test/test_empty_tag_filter.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: BSD
+#
+# This file is part of Pyosmium.
+#
+# Copyright (C) 2024 Sarah Hoffmann.
+import osmium as o
+
+import pytest
+
+class IDCollector:
+
+    def __init__(self):
+        self.nodes = []
+        self.ways = []
+        self.relations = []
+
+    def node(self, n):
+        self.nodes.append(n.id)
+
+    def way(self, w):
+        self.ways.append(w.id)
+
+    def relation(self, r):
+        self.relations.append(r.id)
+
+
+@pytest.fixture
+def reader(opl_reader):
+    return opl_reader("""\
+               n1 x1 y1
+               n2 x1 y1 Tfoo=bar
+               w1 Nn1,n2 Thighway=road
+               w34 Nn2,n1
+               r90
+               r91 Tsome=thing
+               """)
+
+def test_filter_default_config(reader):
+    pre = IDCollector()
+    post = IDCollector()
+    o.apply(reader, pre, o.filter.EmptyTagFilter(), post)
+
+    assert pre.nodes == [1, 2]
+    assert post.nodes == [2]
+    assert pre.ways == [1, 34]
+    assert post.ways == [1]
+    assert pre.relations == [90, 91]
+    assert post.relations == [91]
+
+
+def test_filter_inverted(reader):
+    pre = IDCollector()
+    post = IDCollector()
+    o.apply(reader, pre, o.filter.EmptyTagFilter().invert(), post)
+
+    assert pre.nodes == [1, 2]
+    assert post.nodes == [1]
+    assert pre.ways == [1, 34]
+    assert post.ways == [34]
+    assert pre.relations == [90, 91]
+    assert post.relations == [90]
+
+
+def test_filter_restrict_entity(reader):
+    pre = IDCollector()
+    post = IDCollector()
+    o.apply(reader, pre, o.filter.EmptyTagFilter().enable_for(o.osm.WAY | o.osm.RELATION), post)
+
+    assert pre.nodes == [1, 2]
+    assert post.nodes == [1, 2]
+    assert pre.ways == [1, 34]
+    assert post.ways == [1]
+    assert pre.relations == [90, 91]
+    assert post.relations == [91]
+
+
+def test_filter_restrict_entity_invert(reader):
+    pre = IDCollector()
+    post = IDCollector()
+    o.apply(reader, pre, o.filter.EmptyTagFilter().enable_for(o.osm.NODE).invert(), post)
+
+    assert pre.nodes == [1, 2]
+    assert post.nodes == [1]
+    assert pre.ways == [1, 34]
+    assert post.ways == [1, 34]
+    assert pre.relations == [90, 91]
+    assert post.relations == [90, 91]
+
+
+def test_filter_chained(reader):
+    pre = IDCollector()
+    post = IDCollector()
+    o.apply(reader, pre,
+            o.filter.EmptyTagFilter().enable_for(o.osm.NODE).invert(False),
+            o.filter.EmptyTagFilter().enable_for(o.osm.WAY).invert(True),
+            post)
+
+    assert pre.nodes == [1, 2]
+    assert post.nodes == [2]
+    assert pre.ways == [1, 34]
+    assert post.ways == [34]
+    assert pre.relations == [90, 91]
+    assert post.relations == [90, 91]

--- a/test/test_empty_tag_filter.py
+++ b/test/test_empty_tag_filter.py
@@ -7,22 +7,7 @@ import osmium as o
 
 import pytest
 
-class IDCollector:
-
-    def __init__(self):
-        self.nodes = []
-        self.ways = []
-        self.relations = []
-
-    def node(self, n):
-        self.nodes.append(n.id)
-
-    def way(self, w):
-        self.ways.append(w.id)
-
-    def relation(self, r):
-        self.relations.append(r.id)
-
+from helpers import IDCollector
 
 @pytest.fixture
 def reader(opl_reader):

--- a/test/test_empty_tag_filter.py
+++ b/test/test_empty_tag_filter.py
@@ -18,6 +18,8 @@ def reader(opl_reader):
                w34 Nn2,n1
                r90
                r91 Tsome=thing
+               c222 Ttodo=done
+               c223
                """)
 
 def test_filter_default_config(reader):
@@ -31,6 +33,8 @@ def test_filter_default_config(reader):
     assert post.ways == [1]
     assert pre.relations == [90, 91]
     assert post.relations == [91]
+    assert pre.changesets == [222, 223]
+    assert post.changesets == [222]
 
 
 def test_filter_restrict_entity(reader):

--- a/test/test_empty_tag_filter.py
+++ b/test/test_empty_tag_filter.py
@@ -33,19 +33,6 @@ def test_filter_default_config(reader):
     assert post.relations == [91]
 
 
-def test_filter_inverted(reader):
-    pre = IDCollector()
-    post = IDCollector()
-    o.apply(reader, pre, o.filter.EmptyTagFilter().invert(), post)
-
-    assert pre.nodes == [1, 2]
-    assert post.nodes == [1]
-    assert pre.ways == [1, 34]
-    assert post.ways == [34]
-    assert pre.relations == [90, 91]
-    assert post.relations == [90]
-
-
 def test_filter_restrict_entity(reader):
     pre = IDCollector()
     post = IDCollector()
@@ -59,30 +46,17 @@ def test_filter_restrict_entity(reader):
     assert post.relations == [91]
 
 
-def test_filter_restrict_entity_invert(reader):
-    pre = IDCollector()
-    post = IDCollector()
-    o.apply(reader, pre, o.filter.EmptyTagFilter().enable_for(o.osm.NODE).invert(), post)
-
-    assert pre.nodes == [1, 2]
-    assert post.nodes == [1]
-    assert pre.ways == [1, 34]
-    assert post.ways == [1, 34]
-    assert pre.relations == [90, 91]
-    assert post.relations == [90, 91]
-
-
 def test_filter_chained(reader):
     pre = IDCollector()
     post = IDCollector()
     o.apply(reader, pre,
-            o.filter.EmptyTagFilter().enable_for(o.osm.NODE).invert(False),
-            o.filter.EmptyTagFilter().enable_for(o.osm.WAY).invert(True),
+            o.filter.EmptyTagFilter().enable_for(o.osm.NODE),
+            o.filter.EmptyTagFilter().enable_for(o.osm.WAY),
             post)
 
     assert pre.nodes == [1, 2]
     assert post.nodes == [2]
     assert pre.ways == [1, 34]
-    assert post.ways == [34]
+    assert post.ways == [1]
     assert pre.relations == [90, 91]
     assert post.relations == [90, 91]

--- a/test/test_key_filter.py
+++ b/test/test_key_filter.py
@@ -20,19 +20,22 @@ def test_filter_bad_argument_types(key):
         o.filter.KeyFilter("foo", key)
 
 
-@pytest.mark.parametrize('key,result', [('foo', [1]),
-                                        ('name', [1, 2]),
-                                        ('kö*', [4])])
-def test_filter_simple(opl_reader, key, result):
+@pytest.mark.parametrize('key,nodes,changesets', [('foo', [1], [10]),
+                                                  ('name', [1, 2], [20]),
+                                                  ('kö*', [4], [])])
+def test_filter_simple(opl_reader, key, nodes, changesets):
     data = """\
            n1 Tfoo=bar,name=loo
            n2 Tname=else
            n3 x9 y0
            n4 Tkö*=fr
+           c10 Tfoo=baz
+           c20 Tname=none
            """
 
     post = IDCollector()
 
     o.apply(opl_reader(data), o.filter.KeyFilter(key), post)
 
-    assert post.nodes == result
+    assert post.nodes == nodes
+    assert post.changesets == changesets

--- a/test/test_key_filter.py
+++ b/test/test_key_filter.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: BSD
+#
+# This file is part of Pyosmium.
+#
+# Copyright (C) 2024 Sarah Hoffmann.
+import osmium as o
+
+import pytest
+
+from helpers import IDCollector
+
+def test_filter_no_keys():
+    with pytest.raises(TypeError, match="keys to filter"):
+        o.filter.KeyFilter()
+
+
+@pytest.mark.parametrize('key', [None, 1, IDCollector(), 'a'.encode('utf-8')])
+def test_filter_bad_argument_types(key):
+    with pytest.raises(TypeError, match="must be strings"):
+        o.filter.KeyFilter("foo", key)
+
+
+@pytest.mark.parametrize('key,result', [('foo', [1]),
+                                        ('name', [1, 2]),
+                                        ('kö*', [4])])
+def test_filter_simple(opl_reader, key, result):
+    data = """\
+           n1 Tfoo=bar,name=loo
+           n2 Tname=else
+           n3 x9 y0
+           n4 Tkö*=fr
+           """
+
+    post = IDCollector()
+
+    o.apply(opl_reader(data), o.filter.KeyFilter(key), post)
+
+    assert post.nodes == result


### PR DESCRIPTION
Filter handler can be used to drop irrelevant OSM objects before they are handed into Python callbacks, thus significantly speeding up processing. They can be either used with apply (order matters!):

```
osmium.apply("osm_file.pbf", osmium.filter.KeyFilter('amenity'), MyAmenityHandler())
```

or handed into the apply_file/buffer functions of the SimpleHandler:

```
MyAmenityHandler().apply_file('osm_file.pbf', filters=[osmium.filter.KeyFilter('amenity')])
```

The latter has the advantage that it will correctly work together with the location cache and area handling.

Filters are always implemented in C++. Allowing filters to be defined in Python would defy the purpose of avoiding callbacks into Python. There are two filters defined right now:

* _EmptyTagFilter_ filters out all objects without any tags.
* _KeyFilter_ only lets objects pass that have one of the given keys

Processing a Switzerland extract with the EmptyTagFilter reduces processing time from 40s to 6s.