### PR TITLE
try to make documentation easier to follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ recommended that you put them in a subdirectory `contrib`.
 
 You can do this by cloning their repositories into that location.
 
+Following commands should achieve this:
+
+```
+mkdir contrib
+cd contrib
+git clone https://github.com/osmcode/libosmium.git
+git clone https://github.com/mapbox/protozero.git
+git clone https://github.com/pybind/pybind
+```
+
 You can also set custom locations with `LIBOSMIUM_PREFIX`, `PROTOZERO_PREFIX` and
 `PYBIND11_PREFIX` respectively.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ mkdir contrib
 cd contrib
 git clone https://github.com/osmcode/libosmium.git
 git clone https://github.com/mapbox/protozero.git
-git clone https://github.com/pybind/pybind
+git clone https://github.com/pybind/pybind11.git
 ```
 
 You can also set custom locations with `LIBOSMIUM_PREFIX`, `PROTOZERO_PREFIX` and

--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ pyosmium has the following dependencies:
 
 ### Compiling from Source
 
-Get the latest versions of libosmium, protozero and pybind11. It is
-recommended that you put them in a subdirectory `contrib`. You can also
-set custom locations with `LIBOSMIUM_PREFIX`, `PROTOZERO_PREFIX` and
+Get the latest versions of libosmium, protozero and pybind11 source code. It is
+recommended that you put them in a subdirectory `contrib`. 
+
+You can do this by cloning their repositories into that location.
+
+You can also set custom locations with `LIBOSMIUM_PREFIX`, `PROTOZERO_PREFIX` and
 `PYBIND11_PREFIX` respectively.
 
 To use a custom boost installation, set `BOOST_PREFIX`.


### PR DESCRIPTION
Attempt to make documentation easier to follow.

Disclaimer: I am not 100% is it a good advice but once I did it things started to work.

At least for me it was not obvious what should be put there, especially as 

```
Downloading and adding libosmium sources from https://github.com/osmcode/libosmium/archive/v2.20.0.tar.gz
Downloading and adding protozero sources from https://github.com/mapbox/protozero/archive/v1.7.1.tar.gz
Downloading and adding pybind11 sources from https://github.com/pybind/pybind11/archive/v2.11.1.tar.gz
```

was seen in logs, shortly before erroring out (but for some reason this manual cloning repositories was still needed).

Done as part of #230 in hope that such PR (like some my recent PRs in related repos) are more useful than annoying.