### PR TITLE
Linux aarch64

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,7 +1,9 @@
 name: Build
 
-on: [ push, pull_request ]
-
+on:
+  push:
+    tags:
+      - v**
 
 jobs:
   build_wheels:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,17 +1,19 @@
 name: Build
 
-on:
-  push:
-    tags:
-      - v**
+on: [ push, pull_request ]
+
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} for ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11, macos-14]
+        os: [ubuntu-20.04, windows-2019, macos-14]
+        arch: [auto]
+        include:
+          - os: ubuntu-20.04
+            arch: aarch64
 
     steps:
       - uses: actions/checkout@v4
@@ -34,12 +36,15 @@ jobs:
           ref: v2.20.0
           path: contrib/libosmium
 
+      - name: Set up QEMU
+        if: ${{ matrix.arch == 'aarch64' }}
+        uses: docker/setup-qemu-action@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@v2.20.0
         env:
            CIBW_ARCHS: native
-           CIBW_SKIP: "pp* *musllinux* cp38-macosx_arm64"
+           CIBW_SKIP: "pp* *musllinux* cp38-macosx_arm64 *cp313*"
            CIBW_TEST_REQUIRES: pytest pytest-httpserver shapely
            CIBW_TEST_REQUIRES_LINUX: urllib3<2.0 pytest pytest-httpserver shapely
            CIBW_TEST_COMMAND: pytest {project}/test
@@ -47,9 +52,10 @@ jobs:
            CIBW_BEFORE_BUILD_LINUX: yum install -y sparsehash-devel expat-devel boost-devel zlib-devel bzip2-devel lz4-devel
            CIBW_BEFORE_BUILD_MACOS: brew install boost google-sparsehash
            CIBW_BEFORE_BUILD_WINDOWS: vcpkg install bzip2:x64-windows expat:x64-windows zlib:x64-windows boost-variant:x64-windows boost-iterator:x64-windows lz4:x86-windows
+           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14.0
            CIBW_ENVIRONMENT_WINDOWS: 'CMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake"'
 
       - uses: actions/upload-artifact@v4
         with:
-          name: pyosmium-wheels-${{ matrix.os }}
+          name: pyosmium-wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Install packages
-              run: sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev liblz4-dev
+              run: |
+                sudo apt update -y
+                sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev liblz4-dev
 
             - name: Set up Python 3.6
               uses: actions/setup-python@v5
@@ -188,7 +190,9 @@ jobs:
                   python-version: "${{ matrix.python }}"
 
             - name: Install packages
-              run: sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev liblz4-dev
+              run: |
+                sudo apt update -y
+                sudo apt-get install -y -qq libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev libgeos-dev liblz4-dev
               if: ${{ matrix.flavour == 'linux' }}
 
             - name: Install packages


### PR DESCRIPTION
Mix of enhancements:

1. Added build for Linux aarch64 architecture
 
2. For the workflows to run I added `on: [ push, pull_request ]` and later removed it. **Double-check that it's not accidentally merged**. Workflow output:
   * CI workflow: https://github.com/mtmail/pyosmium/actions/runs/10321503704
   * Build wheels workflow: https://github.com/mtmail/pyosmium/actions/runs/10321503709

3. Increased `cibuildwheel` version to fix "mirrorlist.centos.org does not exist" error

4. Skip `cp313` wheel builds. Python 13 isn't released yet. The error was "GEOS version should be >=3.5, found 3.4.2" so I assume some dependent python package doesn't support Python 13 yet and the latest binary release was too old. (GEOS 3.5 was released 2015).

5. For MacOS set `MACOSX_DEPLOYMENT_TARGET` because the `delocate` that `cibuildwheel`  errored with "Library dependencies do not satisfy target MacOS version 11.0". It should be possible to set the variable to the installed operating system, but cibuildwheel` didn't pick it up. Might work with more debugging

```
      - name: Set MacOS target version
        if: startsWith(matrix.os, 'macos')
        run: |
          sw_vers -productVersion
          echo "MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion)" >> $GITHUB_ENV
```

6. Remove `macos-11` build. https://github.com/actions/runner-images no longer lists it as available. 

7. Add `apt update` because in CI `build-ubuntu (gcc)` and `build-ubuntu (clang)` errored with "Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/c/curl/libcurl4-gnutls-dev_7.81.0-1ubuntu1.16_amd64.deb"

Feel free to pick and choose any of the fixes or ignore the PR until the next release.
