### PR TITLE
fix two python 3.12 deprecation warnings

### DIFF
--- a/tools/pyosmium-up-to-date
+++ b/tools/pyosmium-up-to-date
@@ -98,7 +98,7 @@ def update_from_custom_server(url, seq, ts, options):
             ts = ts.timestamp
 
         if not options.force_update:
-            cmpdate = dt.datetime.utcnow() - dt.timedelta(days=90)
+            cmpdate = dt.datetime.now(dt.UTC) - dt.timedelta(days=90)
             cmpdate = cmpdate.replace(tzinfo=dt.timezone.utc)
             if ts < cmpdate:
                 log.error(
@@ -182,7 +182,7 @@ def compute_start_point(options):
 
 def get_arg_parser(from_main=False):
     def h(s):
-        return re.sub("\s\s+" , " ", s)
+        return re.sub(r'\s\s+' , " ", s)
 
     parser = ArgumentParser(description=__doc__,
                             usage=None if from_main else 'pyosmium-up-to-date [options] <osm file>',


### PR DESCRIPTION
Deals with two warnings Python 3.12 prints

```
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled
for removal in a future version. Use timezone-aware objects to represent datetimes
in UTC: datetime.datetime.now(datetime.UTC).
```

```
 SyntaxWarning: invalid escape sequence '\s'
  return re.sub("\s\s+" , " ", s)
```
