### PR TITLE
setup.py: detect parallellism instead of using hardcoded -j2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,8 @@ class CMakeBuild(build_ext):
             build_args += ['--', '/m']
         else:
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
-            build_args += ['--', '-j2']
+            nbr_cpus = os.cpu_count() or 2 # fallback if None is returned
+            build_args += ['--', f'-j{nbr_cpus}']
 
         env = os.environ.copy()
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),


### PR DESCRIPTION
On my machine (12-core laptop), this makes 'pip install .' go from 1m56 to 58s. I would have expected a bigger performance gain,
but I think the lto at the end of the build is probably taking up the rest of the time.