### PR TITLE
Correct location of py.typed file in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ include lib/*.h
 include lib/*.cc
 include examples/*py
 include test/*py
-include src/py.typed
+include src/osmium/py.typed
 recursive-include src *.pyi
 recursive-include docs *md *css
 include docs/cookbooks/*.ipynb


### PR DESCRIPTION
`py.typed` is of course located in the package.

@sebastic I noticed that `py.typed` is missing in the Debian package for 4.0.0. Could you confirm that this will fix the issue? Then I would do a new release.