### PR TITLE
fix typo in sample sell script

### DIFF
--- a/docs/user_manual/10-Replication-Tools.md
+++ b/docs/user_manual/10-Replication-Tools.md
@@ -191,5 +191,6 @@ while true; do
   else
     echo "Fatal error, stopping updates."
     exit $status
+  fi
 done
 ```


### PR DESCRIPTION
I think a trailing `fi` is missing here, or?