### PR TITLE
Github Actions: update to Ubuntu-22 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,14 +149,14 @@ jobs:
                     - compiler: gcc-old
                       cc: gcc-10
                       cxx: g++-10
-                      platform: ubuntu-20.04
+                      platform: ubuntu-22.04
                       python: 3.7
                       deps: release
                       flavour: linux
                     - compiler: clang-old
-                      cc: clang-10
-                      cxx: clang++-10
-                      platform: ubuntu-20.04
+                      cc: clang-13
+                      cxx: clang++-13
+                      platform: ubuntu-22.04
                       python: 3.7
                       deps: release
                       flavour: linux

--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ pyosmium has the following dependencies:
  * [libz](https://www.zlib.net/)
  * [libbz2](https://www.sourceware.org/bzip2/)
  * [Boost](https://www.boost.org/) variant and iterator >= 1.41
- * [Python Requests](https://docs.python-requests.org/en/master/)
+ * [Python Requests](https://docs.python-requests.org/)
  * Python setuptools
- * [Requests](https://requests.readthedocs.io)
- * a C++17-compatible compiler (Clang 7+, GCC 8+)
+ * a C++17-compatible compiler (Clang 13+, GCC 10+ are supported)
 
 ### Compiling from Source
 


### PR DESCRIPTION
Github Actions will pull the Ubuntu 20.04 images beginning of April, so update to Ubuntu-22.04 for the tests for old versions. This means that the officially supported gcc/clang versions change accordingly to what is supported in the Ubuntu 22 image.

Leaving updating the wheel-build actions for the next release.