### PR TITLE
Fix bug in geojson example, and rename some variables in examples for clarity

### DIFF
--- a/examples/amenity_list.py
+++ b/examples/amenity_list.py
@@ -7,13 +7,13 @@ Points and areas will be processed, unclosed ways will be skipped.
 This example shows how geometries from osmium objects can be imported
 into shapely using the WKBFactory.
 """
-import osmium as o
+import osmium
 import sys
 import shapely.wkb as wkblib
 
-wkbfab = o.geom.WKBFactory()
+wkbfab = osmium.geom.WKBFactory()
 
-class AmenityListHandler(o.SimpleHandler):
+class AmenityListHandler(osmium.SimpleHandler):
 
     def print_amenity(self, tags, lon, lat):
         name = tags.get('name', '')
@@ -33,7 +33,7 @@ def main(osmfile):
 
     handler = AmenityListHandler()
 
-    handler.apply_file(osmfile, filters=[o.filter.KeyFilter('amenity')])
+    handler.apply_file(osmfile, filters=[osmium.filter.KeyFilter('amenity')])
 
     return 0
 

--- a/examples/convert.py
+++ b/examples/convert.py
@@ -4,7 +4,7 @@ Converts a file from one format to another.
 This example shows how to write objects to a file.
 """
 
-import osmium as o
+import osmium
 
 import sys
 
@@ -13,9 +13,9 @@ if __name__ == '__main__':
         print("Usage: python convert.py <infile> <outfile>")
         sys.exit(-1)
 
-    writer = o.SimpleWriter(sys.argv[2])
+    writer = osmium.SimpleWriter(sys.argv[2])
 
-    for obj in o.FileProcessor(sys.argv[1]):
+    for obj in osmium.FileProcessor(sys.argv[1]):
         if obj.is_node():
             writer.add_node(obj)
         elif obj.is_way():

--- a/examples/convert_to_geojson.py
+++ b/examples/convert_to_geojson.py
@@ -48,7 +48,7 @@ class GeoJsonWriter(o.SimpleHandler):
 def main(osmfile):
     handler = GeoJsonWriter()
 
-    handler.apply_file(osmfile,filters=[o.filter.EmptyTagFilter().apply_to(o.osm.NODE)])
+    handler.apply_file(osmfile,filters=[o.filter.EmptyTagFilter().enable_for(o.osm.NODE)])
     handler.finish()
 
     return 0

--- a/examples/convert_to_geojson.py
+++ b/examples/convert_to_geojson.py
@@ -6,11 +6,11 @@ This demonstrates how to use the GeoJSON factory.
 import sys
 import json
 
-import osmium as o
+import osmium
 
-geojsonfab = o.geom.GeoJSONFactory()
+geojsonfab = osmium.geom.GeoJSONFactory()
 
-class GeoJsonWriter(o.SimpleHandler):
+class GeoJsonWriter(osmium.SimpleHandler):
 
     def __init__(self):
         super().__init__()
@@ -21,17 +21,17 @@ class GeoJsonWriter(o.SimpleHandler):
     def finish(self):
         print(']}')
 
-    def node(self, o):
-        if o.tags:
-            self.print_object(geojsonfab.create_point(o), o.tags)
+    def node(self, n):
+        if n.tags:
+            self.print_object(geojsonfab.create_point(n), n.tags)
 
-    def way(self, o):
-        if o.tags and not o.is_closed():
-            self.print_object(geojsonfab.create_linestring(o), o.tags)
+    def way(self, w):
+        if w.tags and not w.is_closed():
+            self.print_object(geojsonfab.create_linestring(w), w.tags)
 
-    def area(self, o):
-        if o.tags:
-            self.print_object(geojsonfab.create_multipolygon(o), o.tags)
+    def area(self, a):
+        if a.tags:
+            self.print_object(geojsonfab.create_multipolygon(a), a.tags)
 
     def print_object(self, geojson, tags):
         geom = json.loads(geojson)
@@ -48,7 +48,7 @@ class GeoJsonWriter(o.SimpleHandler):
 def main(osmfile):
     handler = GeoJsonWriter()
 
-    handler.apply_file(osmfile,filters=[o.filter.EmptyTagFilter().enable_for(o.osm.NODE)])
+    handler.apply_file(osmfile,filters=[osmium.filter.EmptyTagFilter().enable_for(osmium.osm.NODE)])
     handler.finish()
 
     return 0

--- a/examples/create_nodecache.py
+++ b/examples/create_nodecache.py
@@ -1,15 +1,15 @@
-import osmium as o
+import osmium
 import sys
 
 if len(sys.argv) != 3:
     print("Usage: python create_nodecache.py <osm file> <node cache>")
     exit(-1)
 
-reader = o.io.Reader(sys.argv[1], o.osm.osm_entity_bits.NODE)
+reader = osmium.io.Reader(sys.argv[1], osmium.osm.osm_entity_bits.NODE)
 
-idx = o.index.create_map("sparse_file_array," + sys.argv[2])
-lh = o.NodeLocationsForWays(idx)
+idx = osmium.index.create_map("sparse_file_array," + sys.argv[2])
+lh = osmium.NodeLocationsForWays(idx)
 
-o.apply(reader, lh)
+osmium.apply(reader, lh)
 
 reader.close()

--- a/examples/filter_coastlines.py
+++ b/examples/filter_coastlines.py
@@ -7,7 +7,7 @@ We need to go twice over the file. First read the ways, filter the ones
 we are interested in and remember the nodes required. Then, in a second
 run all the relevant nodes and ways are written out.
 """
-import osmium as o
+import osmium
 import sys
 
 
@@ -16,25 +16,23 @@ if __name__ == '__main__':
         print("Usage: python filter_coastlines.py <infile> <outfile>")
         sys.exit(-1)
 
-
     # go through the ways to find all relevant nodes
     nodes = set()
     # Pre-filter the ways by tags. The less object we need to look at, the better.
-    way_filter = o.filter.KeyFilter('natural')
+    way_filter = osmium.filter.KeyFilter('natural')
     # only scan the ways of the file
-    for obj in o.FileProcessor(sys.argv[1], o.osm.WAY).with_filter(way_filter):
+    for obj in osmium.FileProcessor(sys.argv[1], osmium.osm.WAY).with_filter(way_filter):
         if obj.tags['natural'] == 'coastline':
             nodes.update(n.ref for n in obj.nodes)
 
-
     # go through the file again and write out the data
-    writer = o.SimpleWriter(sys.argv[2])
+    writer = osmium.SimpleWriter(sys.argv[2])
 
     # This time the pre-filtering should only apply to ways.
-    way_filter = o.filter.KeyFilter('natural').enable_for(o.osm.WAY)
+    way_filter = osmium.filter.KeyFilter('natural').enable_for(osmium.osm.WAY)
 
     # We need nodes and ways in the second pass.
-    for obj in o.FileProcessor(sys.argv[1], o.osm.WAY | o.osm.NODE).with_filter(way_filter):
+    for obj in osmium.FileProcessor(sys.argv[1], osmium.osm.WAY | osmium.osm.NODE).with_filter(way_filter):
         if obj.is_node() and obj.id in nodes:
             # Strip the object of tags along the way
             writer.add_node(obj.replace(tags={}))

--- a/examples/normalize_boolean.py
+++ b/examples/normalize_boolean.py
@@ -3,10 +3,10 @@ This example shows how to filter and modify tags and write the results back.
 It changes all tag values 'yes/no' to '1/0'.
 """
 
-import osmium as o
+import osmium
 import sys
 
-class BoolNormalizer(o.SimpleHandler):
+class BoolNormalizer(osmium.SimpleHandler):
 
     def __init__(self, writer):
         super(BoolNormalizer, self).__init__()
@@ -44,14 +44,14 @@ class BoolNormalizer(o.SimpleHandler):
             # and discard the tag list we just created.
             return o
 
-    def node(self, o):
-        self.writer.add_node(self.normalize(o))
+    def node(self, n):
+        self.writer.add_node(self.normalize(n))
 
-    def way(self, o):
-        self.writer.add_way(self.normalize(o))
+    def way(self, w):
+        self.writer.add_way(self.normalize(w))
 
-    def relation(self, o):
-        self.writer.add_relation(self.normalize(o))
+    def relation(self, r):
+        self.writer.add_relation(self.normalize(r))
 
 
 if __name__ == '__main__':
@@ -59,8 +59,7 @@ if __name__ == '__main__':
         print("Usage: python normalize_boolean.py <infile> <outfile>")
         sys.exit(-1)
 
-
-    writer = o.SimpleWriter(sys.argv[2])
+    writer = osmium.SimpleWriter(sys.argv[2])
     BoolNormalizer(writer).apply_file(sys.argv[1])
 
     writer.close()

--- a/examples/osm_diff_stats.py
+++ b/examples/osm_diff_stats.py
@@ -4,7 +4,7 @@ Simple example that counts the number of changes in an osm diff file.
 Shows how to detect the different kind of modifications and how to
 use the handler generator function instead of a handler class.
 """
-import osmium as o
+import osmium
 import sys
 
 class Stats:
@@ -31,7 +31,7 @@ class Stats:
 def main(osmfile):
     stats = {t: Stats() for t in 'nwr'}
 
-    for obj in o.FileProcessor(osmfile):
+    for obj in osmium.FileProcessor(osmfile):
         stats[obj.type_str()].add(obj)
 
     stats['n'].outstats("Nodes")

--- a/examples/osm_file_stats.py
+++ b/examples/osm_file_stats.py
@@ -3,10 +3,10 @@ Simple example that counts the number of objects in an osm file.
 
 Shows how to write a handler for the different types of objects.
 """
-import osmium as o
+import osmium
 import sys
 
-class FileStatsHandler(o.SimpleHandler):
+class FileStatsHandler(osmium.SimpleHandler):
 
     def __init__(self):
         super(FileStatsHandler, self).__init__()

--- a/examples/osm_replication_stats.py
+++ b/examples/osm_replication_stats.py
@@ -4,7 +4,7 @@ starting from a given timestamp for a maximum of n hours.
 
 Shows how to detect the different kind of modifications.
 """
-import osmium as o
+import osmium as osmium
 import sys
 import datetime as dt
 import osmium.replication.server as rserv
@@ -30,7 +30,7 @@ class Stats(object):
         print("%s modified: %d" % (prefix, self.modified))
         print("%s deleted: %d" % (prefix, self.deleted))
 
-class FileStatsHandler(o.SimpleHandler):
+class FileStatsHandler(osmium.SimpleHandler):
     def __init__(self):
         super(FileStatsHandler, self).__init__()
         self.nodes = Stats()

--- a/examples/road_length.py
+++ b/examples/road_length.py
@@ -3,20 +3,20 @@ Compute the total length of highways in an osm file.
 
 Shows how to extract the geometry of a way.
 """
-import osmium as o
+import osmium
 import sys
 
 def main(osmfile):
     total = 0.0
     # As we need the way geometry, the node locations need to be cached.
     # This is enabled with the with_locations() function.
-    for obj in o.FileProcessor(osmfile, o.osm.NODE | o.osm.WAY)\
+    for obj in osmium.FileProcessor(osmfile, osmium.osm.NODE | osmium.osm.WAY)\
                 .with_locations()\
-                .with_filter(o.filter.KeyFilter('highway')):
+                .with_filter(osmium.filter.KeyFilter('highway')):
         if obj.is_way():
             try:
-                total += o.geom.haversine_distance(obj.nodes)
-            except o.InvalidLocationError:
+                total += osmium.geom.haversine_distance(obj.nodes)
+            except osmium.InvalidLocationError:
                 # A location error might occur if the osm file is an extract
                 # where nodes of ways near the boundary are missing.
                 print("WARNING: way %d incomplete. Ignoring." % obj.id)

--- a/examples/use_nodecache.py
+++ b/examples/use_nodecache.py
@@ -1,7 +1,7 @@
 """
 Iterate over all ways (and ways only) using node cache to obtain geometries
 """
-import osmium as o
+import osmium
 import sys
 
 class WayHandler:
@@ -18,12 +18,12 @@ if len(sys.argv) != 3:
     print("Usage: python use_nodecache.py <osm file> <node cache>")
     exit()
 
-reader = o.io.Reader(sys.argv[1], o.osm.osm_entity_bits.WAY)
+reader = osmium.io.Reader(sys.argv[1], osmium.osm.osm_entity_bits.WAY)
 
-idx = o.index.create_map("sparse_file_array," + sys.argv[2])
-lh = o.NodeLocationsForWays(idx)
+idx = osmium.index.create_map("sparse_file_array," + sys.argv[2])
+lh = osmium.NodeLocationsForWays(idx)
 lh.ignore_errors()
 
-o.apply(reader, lh, WayHandler(idx))
+osmium.apply(reader, lh, WayHandler(idx))
 
 reader.close()


### PR DESCRIPTION
This PR does two things:

1. Changes `EmptyTagFilter().apply_to()` to `EmptyTagFilter().enable_for()` in the GeoJSON example, so that the example works (see first commit).
2. Renames some variables in the examples (see second and third commits). I found it confusing that the name `o` was used both for the osmium library and also for an OSM Node/Way/Relation, such that the latter sometimes shadowed the former. So I changed the examples to refer to the library by its full name, and to refer to OSM objects as `n/w/a/r` if their type is known (e.g. when they are arguments to the `node/way/area/relation` handler functions). I tested all of the examples to make sure they still worked after the changes.

Let me know if you have any feedback on these changes, and thanks for maintaining pyosmium.