### PR TITLE
using UTC timezone singleton instead of datetime.UTC alias

### DIFF
--- a/tools/pyosmium-up-to-date
+++ b/tools/pyosmium-up-to-date
@@ -98,7 +98,7 @@ def update_from_custom_server(url, seq, ts, options):
             ts = ts.timestamp
 
         if not options.force_update:
-            cmpdate = dt.datetime.now(dt.UTC) - dt.timedelta(days=90)
+            cmpdate = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=90)
             cmpdate = cmpdate.replace(tzinfo=dt.timezone.utc)
             if ts < cmpdate:
                 log.error(


### PR DESCRIPTION
`datetime.UTC` introduced only since 3.11https://docs.python.org/3.11/library/datetime.html#datetime.UTC

Fixing it for [3.7 - 3.11) versions
```
Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime
>>> datetime.UTC
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'datetime' has no attribute 'UTC'
```