### PR TITLE
Fix paths to pyfiles for manpage generation.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@ ARGPARSE_BASEARGS=--author 'Sarah Hoffmann' --author-email 'lonvia@denofr.de' --
 
 man:
 	mkdir -p man
-	argparse-manpage --pyfile ../tools/pyosmium-get-changes --function get_arg_parser ${ARGPARSE_BASEARGS} --output man/pyosmium-get-changes.1
-	argparse-manpage --pyfile ../tools/pyosmium-up-to-date --function get_arg_parser ${ARGPARSE_BASEARGS} --output man/pyosmium-up-to-date.1
+	argparse-manpage --pyfile ../src/osmium/tools/pyosmium_get_changes.py --function get_arg_parser ${ARGPARSE_BASEARGS} --output man/pyosmium-get-changes.1
+	argparse-manpage --pyfile ../src/osmium/tools/pyosmium_up_to_date.py --function get_arg_parser ${ARGPARSE_BASEARGS} --output man/pyosmium-up-to-date.1
 
 .PHONY: man


### PR DESCRIPTION
Manpage generated was broken by the changes in ac17b821bc50b3f746e7338bc5713bc1d2305fd4.