### PR TITLE
Add support for end dates/IDs to diff processing functions

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@ ARGPARSE_BASEARGS=--author 'Sarah Hoffmann' --author-email 'lonvia@denofr.de' --
 
 man:
 	mkdir -p man
-	argparse-manpage --pyfile ../src/osmium/tools/pyosmium_get_changes.py --function get_arg_parser ${ARGPARSE_BASEARGS} --output man/pyosmium-get-changes.1
-	argparse-manpage --pyfile ../src/osmium/tools/pyosmium_up_to_date.py --function get_arg_parser ${ARGPARSE_BASEARGS} --output man/pyosmium-up-to-date.1
+	argparse-manpage --module osmium.tools.pyosmium_get_changes --function get_arg_parser ${ARGPARSE_BASEARGS} --output man/pyosmium-get-changes.1
+	argparse-manpage --module osmium.tools.pyosmium_up_to_date --function get_arg_parser ${ARGPARSE_BASEARGS} --output man/pyosmium-up-to-date.1
 
 .PHONY: man

--- a/docs/man/pyosmium-get-changes.1
+++ b/docs/man/pyosmium-get-changes.1
@@ -1,4 +1,4 @@
-.TH PYOSMIUM\-GET\-CHANGES "1" "2025\-09\-09" "pyosmium" "Generated Python Manual"
+.TH PYOSMIUM\-GET\-CHANGES "1" "2025\-10\-05" "pyosmium" "Generated Python Manual"
 .SH NAME
 pyosmium\-get\-changes
 .SH SYNOPSIS
@@ -56,7 +56,7 @@ Netscape\-style cookie jar file to read cookies from and where received cookies 
 
 .TP
 \fB\-s\fR \fI\,OUTSIZE\/\fR, \fB\-\-size\fR \fI\,OUTSIZE\/\fR
-Maximum data to load in MB (default: 100MB).
+Maximum data to load in MB (Defaults to 100MB when no end date/ID has been set).
 
 .TP
 \fB\-I\fR \fI\,ID\/\fR, \fB\-\-start\-id\fR \fI\,ID\/\fR
@@ -69,6 +69,14 @@ Date when to start updates
 .TP
 \fB\-O\fR \fI\,OSMFILE\/\fR, \fB\-\-start\-osm\-data\fR \fI\,OSMFILE\/\fR
 start at the date of the newest OSM object in the file
+
+.TP
+\fB\-\-end\-id\fR \fI\,ID\/\fR
+Last sequence ID to download.
+
+.TP
+\fB\-E\fR \fI\,DATE\/\fR, \fB\-\-end\-date\fR \fI\,DATE\/\fR
+Do not download diffs later than the given date.
 
 .TP
 \fB\-f\fR \fI\,SEQ_FILE\/\fR, \fB\-\-sequence\-file\fR \fI\,SEQ_FILE\/\fR

--- a/docs/man/pyosmium-up-to-date.1
+++ b/docs/man/pyosmium-up-to-date.1
@@ -1,4 +1,4 @@
-.TH PYOSMIUM\-UP\-TO\-DATE "1" "2025\-09\-09" "pyosmium" "Generated Python Manual"
+.TH PYOSMIUM\-UP\-TO\-DATE "1" "2025\-10\-05" "pyosmium" "Generated Python Manual"
 .SH NAME
 pyosmium\-up\-to\-date
 .SH SYNOPSIS
@@ -57,8 +57,20 @@ Format the data should be saved in. Usually determined from file name.
 Base URL of the replication server. Default: https://planet.osm.org/replication/hour/ (hourly diffs from osm.org)
 
 .TP
+\fB\-\-diff\-type\fR \fI\,SERVER_DIFF_TYPE\/\fR
+File format used by the replication server (default: osc.gz)
+
+.TP
 \fB\-s\fR \fI\,SIZE\/\fR, \fB\-\-size\fR \fI\,SIZE\/\fR
-Maximum size of change to apply at once in MB. Default: 1GB
+Maximum size of change to apply at once in MB. Defaults to 1GB when no end ID or date was given.
+
+.TP
+\fB\-\-end\-id\fR \fI\,ID\/\fR
+Last sequence ID to download.
+
+.TP
+\fB\-E\fR \fI\,DATE\/\fR, \fB\-\-end\-date\fR \fI\,DATE\/\fR
+Do not download diffs later than the given date.
 
 .TP
 \fB\-\-tmpdir\fR \fI\,TMPDIR\/\fR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,6 @@ include = ['/src/**/*.py',
            '/contrib/protozero/LICENSE',
            '/contrib/protozero/README.md',
            ]
+
+[tool.pytest.ini_options]
+log_cli = false

--- a/src/osmium/tools/common.py
+++ b/src/osmium/tools/common.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This file is part of pyosmium. (https://osmcode.org/pyosmium/)
+#
+# Copyright (C) 2025 Sarah Hoffmann <lonvia@denofr.de> and others.
+# For a full list of authors see the git log.
+from typing import Optional
+import logging
+from dataclasses import dataclass
+import datetime as dt
+from argparse import ArgumentTypeError
+
+from ..replication import newest_change_from_file
+from ..replication.server import ReplicationServer
+from ..replication.utils import get_replication_header
+
+
+log = logging.getLogger()
+
+
+@dataclass
+class ReplicationStart:
+    """ Represents the point where changeset download should begin.
+    """
+    date: Optional[dt.datetime] = None
+    seq_id: Optional[int] = None
+    source: Optional[str] = None
+
+    def get_sequence(self, svr: ReplicationServer) -> Optional[int]:
+        if self.seq_id is not None:
+            log.debug("Using given sequence ID %d" % self.seq_id)
+            return self.seq_id + 1
+
+        assert self.date is not None
+        log.debug("Looking up sequence ID for timestamp %s" % self.date)
+        return svr.timestamp_to_sequence(self.date)
+
+    def get_end_sequence(self, svr: ReplicationServer) -> Optional[int]:
+        if self.seq_id is not None:
+            log.debug("Using end sequence ID %d" % self.seq_id)
+            return self.seq_id
+
+        assert self.date is not None
+        log.debug("Looking up end sequence ID for timestamp %s" % self.date)
+        return svr.timestamp_to_sequence(self.date)
+
+    @staticmethod
+    def from_id(idstr: str) -> 'ReplicationStart':
+        try:
+            seq_id = int(idstr)
+        except ValueError:
+            raise ArgumentTypeError("Sequence id '%s' is not a number" % idstr)
+
+        if seq_id < -1:
+            raise ArgumentTypeError("Sequence id '%s' is negative" % idstr)
+
+        return ReplicationStart(seq_id=seq_id)
+
+    @staticmethod
+    def from_date(datestr: str) -> 'ReplicationStart':
+        try:
+            date = dt.datetime.strptime(datestr, "%Y-%m-%dT%H:%M:%SZ")
+            date = date.replace(tzinfo=dt.timezone.utc)
+        except ValueError:
+            raise ArgumentTypeError(
+                "Date needs to be in ISO8601 format (e.g. 2015-12-24T08:08:08Z).")
+
+        return ReplicationStart(date=date)
+
+    @staticmethod
+    def from_osm_file(fname: str, ignore_headers: bool) -> 'ReplicationStart':
+        if ignore_headers:
+            ts = None
+            seq = None
+            url = None
+        else:
+            try:
+                (url, seq, ts) = get_replication_header(fname)
+            except RuntimeError as e:
+                raise ArgumentTypeError(e)
+
+        if ts is None and seq is None:
+            log.debug("OSM file has no replication headers. Looking for newest OSM object.")
+            try:
+                ts = newest_change_from_file(fname)
+            except RuntimeError as e:
+                raise ArgumentTypeError(e)
+
+            if ts is None:
+                raise ArgumentTypeError("OSM file does not seem to contain valid data.")
+
+        return ReplicationStart(seq_id=seq, date=ts, source=url)

--- a/src/osmium/tools/pyosmium_up_to_date.py
+++ b/src/osmium/tools/pyosmium_up_to_date.py
@@ -1,3 +1,9 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This file is part of pyosmium. (https://osmcode.org/pyosmium/)
+#
+# Copyright (C) 2025 Sarah Hoffmann <lonvia@denofr.de> and others.
+# For a full list of authors see the git log.
 """
 Update an OSM file with changes from a OSM replication server.
 
@@ -29,38 +35,42 @@ pyosmium-up-to-date does not fetch the cookie from these services for you.
 However, it can read cookies from a Netscape-style cookie jar file, send these
 cookies to the server and will save received cookies to the jar file.
 """
+from typing import Any, List
 import sys
 import traceback
 import logging
 import http.cookiejar
 
-from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from argparse import ArgumentParser, RawDescriptionHelpFormatter, ArgumentTypeError
 import datetime as dt
-from osmium.replication import server as rserv
-from osmium.replication.utils import get_replication_header
-from osmium.replication import newest_change_from_file
-from osmium.version import pyosmium_release
 from textwrap import dedent as msgfmt
 from tempfile import mktemp
 import os.path
 
+from ..replication import server as rserv
+from ..version import pyosmium_release
+from .common import ReplicationStart
+
 log = logging.getLogger()
 
 
-def update_from_osm_server(ts, options):
-    """Update the OSM file using the official OSM servers at
-       https://planet.osm.org/replication. This strategy will attempt
-       to start with daily updates before going down to minutelies.
-       TODO: only updates from hourlies currently implemented.
+def update_from_osm_server(start: ReplicationStart, options: Any) -> int:
+    """ Update the OSM file using the official OSM servers at
+        https://planet.osm.org/replication. This strategy will attempt
+        to start with daily updates before going down to minutelies.
+        TODO: only updates from hourlies currently implemented.
     """
-    return update_from_custom_server("https://planet.osm.org/replication/hour/",
-                                     None, ts, options)
+    start.source = "https://planet.osm.org/replication/hour/"
+    return update_from_custom_server(start, options)
 
 
-def update_from_custom_server(url, seq, ts, options):
-    """Update from a custom URL, simply using the diff sequence as is."""
-    with rserv.ReplicationServer(url, "osc.gz") as svr:
-        log.info("Using replication service at %s", url)
+def update_from_custom_server(start: ReplicationStart, options: Any) -> int:
+    """ Update from a custom URL, simply using the diff sequence as is.
+    """
+    assert start.source
+
+    with rserv.ReplicationServer(start.source, options.server_diff_type) as svr:
+        log.info(f"Using replication service at {start.source}")
 
         svr.set_request_parameter('timeout', options.socket_timeout or None)
 
@@ -73,39 +83,37 @@ def update_from_custom_server(url, seq, ts, options):
         if current is None:
             log.error("Cannot download state information. Is the replication URL correct?")
             return 3
-        log.debug("Server is at sequence %d (%s).", current.sequence, current.timestamp)
+        log.debug(f"Server is at sequence {current.sequence} ({current.timestamp}).")
 
-        if seq is None:
-            log.info("Using timestamp %s as starting point." % ts)
-            startseq = svr.timestamp_to_sequence(ts)
-            if startseq is None:
-                log.error("No starting point found for time %s on server %s"
-                          % (str(ts), url))
-                return 3
-        else:
-            if seq >= current.sequence:
-                log.info("File is already up to date.")
-                return 0
+        if start.seq_id is not None and start.seq_id >= current.sequence:
+            log.info("File is already up to date.")
+            return 0
 
-            log.debug("Using given sequence ID %d" % seq)
-            startseq = seq + 1
-            ts = svr.get_state_info(seq=startseq)
-            if ts is None:
-                log.error("Cannot download state information for ID %d. Is the URL correct?" % seq)
+        startseq = start.get_sequence(svr)
+        if startseq is None:
+            log.error(f"No starting point found for time {start.date} on server {start.source}")
+            return 3
+
+        if start.date is None:
+            start_state = svr.get_state_info(seq=startseq)
+            if start_state is None:
+                log.error(f"Cannot download state information for ID {startseq}. "
+                          'Is the URL correct?')
                 return 3
-            ts = ts.timestamp
+            start.date = start_state.timestamp
 
         if not options.force_update:
             cmpdate = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=90)
             cmpdate = cmpdate.replace(tzinfo=dt.timezone.utc)
-            if ts < cmpdate:
+            if start.date < cmpdate:
                 log.error(
                   """The OSM file is more than 3 months old. You should download a
                      more recent file instead of updating. If you really want to
                      update the file, use --force-update-of-old-planet.""")
                 return 3
 
-        log.info("Starting download at ID %d (max %d MB)" % (startseq, options.outsize))
+        log.info("Starting download at ID %d (max %f MB)"
+                 % (startseq, options.outsize or float('inf')))
 
         outfile = options.outfile
         infile = options.infile
@@ -118,10 +126,25 @@ def update_from_custom_server(url, seq, ts, options):
         else:
             ofname = outfile
 
+        if options.outsize is not None:
+            max_size = options.outsize * 1024
+        elif options.end is None:
+            max_size = 1024 * 1024
+        else:
+            max_size = None
+
+        if options.end is None:
+            end_id = None
+        else:
+            end_id = options.end.get_end_sequence(svr)
+            if end_id is None:
+                log.error("Cannot find the end date/ID on the server.")
+                return 1
+
         try:
             extra_headers = {'generator': 'pyosmium-up-to-date/' + pyosmium_release}
             outseqs = svr.apply_diffs_to_file(infile, ofname, startseq,
-                                              max_size=options.outsize*1024,
+                                              max_size=max_size, end_id=end_id,
                                               extra_headers=extra_headers,
                                               outformat=options.outformat)
 
@@ -144,41 +167,35 @@ def update_from_custom_server(url, seq, ts, options):
     if options.cookie:
         cookie_jar.save(options.cookie)
 
-    return 0 if outseqs[1] == outseqs[0] else 1
+    return 0 if (end_id or outseqs[1]) == outseqs[0] else 1
 
 
-def compute_start_point(options):
-    if options.ignore_headers:
-        url, seq, ts = None, None, None
-    else:
-        url, seq, ts = get_replication_header(options.infile)
+def compute_start_point(options: Any) -> ReplicationStart:
+    start = ReplicationStart.from_osm_file(options.infile, options.ignore_headers)
 
     if options.server_url is not None:
-        if url is not None and url != options.server_url:
+        if start.source is not None and start.source != options.server_url:
             log.error(msgfmt(f"""
                   You asked to use server URL:
                     {options.server_url}
                   but the referenced OSM file points to replication server:
-                    {url}
+                    {start.source}
                   If you really mean to overwrite the URL, use --ignore-osmosis-headers."""))
-            exit(2)
-        url = options.server_url
+            raise ArgumentTypeError("Source URL doesn't match replication headers.")
+        if start.source is None:
+            start.source = options.server_url
+            start.seq_id = None
+            if start.date is None:
+                raise ArgumentTypeError("Cannot determine start date for file.")
 
-    if seq is None and ts is None:
-        log.info("No replication information found, scanning for newest OSM object.")
-        ts = newest_change_from_file(options.infile)
+    if start.seq_id is None:
+        assert start.date is not None
+        start.date -= dt.timedelta(minutes=options.wind_back)
 
-        if ts is None:
-            log.error("OSM file does not seem to contain valid data.")
-            exit(2)
-
-    if ts is not None:
-        ts -= dt.timedelta(minutes=options.wind_back)
-
-    return url, seq, ts
+    return start
 
 
-def get_arg_parser(from_main=False):
+def get_arg_parser(from_main: bool = False) -> ArgumentParser:
 
     parser = ArgumentParser(prog='pyosmium-up-to-date',
                             description=__doc__,
@@ -197,8 +214,18 @@ def get_arg_parser(from_main=False):
                         help='Base URL of the replication server. Default: '
                              'https://planet.osm.org/replication/hour/ '
                              '(hourly diffs from osm.org)')
-    parser.add_argument('-s', '--size', dest='outsize', metavar='SIZE', type=int, default=1024,
-                        help='Maximum size of change to apply at once in MB. Default: 1GB')
+    parser.add_argument('--diff-type', action='store', dest='server_diff_type', default='osc.gz',
+                        help='File format used by the replication server (default: osc.gz)')
+    parser.add_argument('-s', '--size', dest='outsize', metavar='SIZE', type=int,
+                        help='Maximum size of change to apply at once in MB. '
+                             'Defaults to 1GB when no end ID or date was given.')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--end-id', dest='end',
+                       type=ReplicationStart.from_id, metavar='ID',
+                       help='Last sequence ID to download.')
+    group.add_argument('-E', '--end-date', dest='end', metavar='DATE',
+                       type=ReplicationStart.from_date,
+                       help='Do not download diffs later than the given date.')
     parser.add_argument('--tmpdir', dest='tmpdir',
                         help='Directory to use for temporary files. '
                              'Usually the directory of input file is used.')
@@ -225,28 +252,28 @@ def get_arg_parser(from_main=False):
     return parser
 
 
-def pyosmium_up_to_date(args):
-    options = get_arg_parser(from_main=True).parse_args()
+def pyosmium_up_to_date(args: List[str]) -> int:
+    options = get_arg_parser(from_main=True).parse_args(args)
     log.setLevel(max(3 - options.loglevel, 0) * 10)
 
     try:
-        url, seq, ts = compute_start_point(options)
+        start = compute_start_point(options)
     except RuntimeError as e:
         log.error(str(e))
         return 2
 
     try:
-        if url is None:
-            return update_from_osm_server(ts, options)
+        if start.source is None:
+            return update_from_osm_server(start, options)
 
-        return update_from_custom_server(url, seq, ts, options)
+        return update_from_custom_server(start, options)
     except Exception:
         traceback.print_exc()
 
     return 254
 
 
-def main():
+def main() -> int:
     logging.basicConfig(stream=sys.stderr,
                         format='%(asctime)s %(levelname)s: %(message)s',
                         datefmt='%Y-%m-%d %H:%M:%S')

--- a/src/osmium/tools/pyosmium_up_to_date.py
+++ b/src/osmium/tools/pyosmium_up_to_date.py
@@ -153,7 +153,7 @@ def update_from_custom_server(start: ReplicationStart, options: Any) -> int:
                 return 3
 
             if outfile is None:
-                os.rename(ofname, infile)
+                os.replace(ofname, infile)
         finally:
             if outfile is None:
                 try:

--- a/test/test_pyosmium_get_changes.py
+++ b/test/test_pyosmium_get_changes.py
@@ -11,7 +11,6 @@ import uuid
 
 import pytest
 
-import osmium.replication.server
 import osmium
 from osmium.tools.pyosmium_get_changes import pyosmium_get_changes
 

--- a/test/test_pyosmium_up-to-date.py
+++ b/test/test_pyosmium_up-to-date.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This file is part of pyosmium. (https://osmcode.org/pyosmium/)
+#
+# Copyright (C) 2025 Sarah Hoffmann <lonvia@denofr.de> and others.
+# For a full list of authors see the git log.
+""" Tests for the pyosmium-up-to-date script.
+"""
+import uuid
+import datetime as dt
+
+import pytest
+import osmium
+from osmium.tools.pyosmium_up_to_date import pyosmium_up_to_date
+import osmium.replication.utils as rutil
+
+from helpers import IDCollector
+
+# Choosing a future date here, so we don't run into pyosmium's check for old
+# data. If you get caught by this: congratulations, you are maintaining a
+# 50-year old test.
+REPLICATION_BASE_TIME = dt.datetime(year=2070, month=5, day=6, hour=20, tzinfo=dt.timezone.utc)
+REPLICATION_BASE_SEQ = 100
+REPLICATION_CURRENT = 140
+
+
+@pytest.fixture
+def replication_server(httpserver):
+    def _state(seq):
+        seqtime = REPLICATION_BASE_TIME + dt.timedelta(hours=seq - REPLICATION_CURRENT)
+        timestamp = seqtime.strftime('%Y-%m-%dT%H\\:%M\\:%SZ')
+        return f"sequenceNumber={seq}\ntimestamp={timestamp}\n"
+
+    httpserver.no_handler_status_code = 404
+    httpserver.expect_request('/state.txt').respond_with_data(_state(REPLICATION_CURRENT))
+    for i in range(REPLICATION_BASE_SEQ, REPLICATION_CURRENT + 1):
+        httpserver.expect_request(f'/000/000/{i}.opl')\
+                  .respond_with_data(f"r{i} M" + ",".join(f"n{i}@" for i in range(1, 6000)))
+        httpserver.expect_request(f'/000/000/{i}.state.txt').respond_with_data(_state(i))
+
+    return httpserver.url_for('')
+
+
+@pytest.fixture
+def runner(replication_server):
+    def _run(*args):
+        return pyosmium_up_to_date(
+            ['--server', replication_server, '--diff-type', 'opl'] + list(map(str, args)))
+
+    return _run
+
+
+def test_no_output_file(runner):
+    with pytest.raises(SystemExit):
+        runner()
+
+
+def test_simple_update_no_windback(runner, test_data):
+    outfile = test_data("n1 v1 t2070-05-06T19:30:00Z")
+
+    assert 0 == runner('--wind-back', 0, outfile)
+
+    ids = IDCollector()
+    osmium.apply(outfile, ids)
+
+    assert ids.nodes == [1]
+    assert ids.relations == list(range(139, REPLICATION_CURRENT + 1))
+
+
+def test_simple_update_override(runner, test_data):
+    outfile = test_data("n1 v1 t2070-05-06T19:30:00Z")
+
+    assert 0 == runner(outfile)
+
+    ids = IDCollector()
+    osmium.apply(outfile, ids)
+
+    assert ids.nodes == [1]
+    assert ids.relations == list(range(138, REPLICATION_CURRENT + 1))
+
+
+def test_simple_update_new_file(runner, replication_server, test_data, tmp_path):
+    outfile = test_data("n1 v1 t2070-05-06T19:30:00Z")
+    newfile = tmp_path / f"{uuid.uuid4()}.pbf"
+
+    assert 0 == runner('-o', str(newfile), outfile)
+
+    ids = IDCollector()
+    osmium.apply(outfile, ids)
+
+    assert ids.nodes == [1]
+    assert ids.relations == []
+
+    ids = IDCollector()
+    osmium.apply(newfile, ids)
+    assert ids.nodes == [1]
+    assert ids.relations == list(range(138, REPLICATION_CURRENT + 1))
+
+    header = rutil.get_replication_header(newfile)
+
+    assert header.url == replication_server
+    assert header.sequence == REPLICATION_CURRENT
+    assert header.timestamp == REPLICATION_BASE_TIME
+
+
+def test_update_sequences(runner, test_data, tmp_path):
+    outfile = test_data("n1 v1 t2070-05-05T10:30:00Z")
+    newfile = tmp_path / f"{uuid.uuid4()}.pbf"
+
+    assert 0 == runner('--end-id', '110', '-o', str(newfile), outfile)
+
+    ids = IDCollector()
+    osmium.apply(newfile, ids)
+    assert ids.nodes == [1]
+    assert ids.relations == list(range(105, 111))
+
+    header = rutil.get_replication_header(newfile)
+
+    assert header.sequence == 110
+
+    # Note: this test only catches holes, no duplicate application.
+    assert 0 == runner(newfile)
+
+    ids = IDCollector()
+    osmium.apply(newfile, ids)
+    assert ids.nodes == [1]
+    assert ids.relations == list(range(105, REPLICATION_CURRENT + 1))
+
+    header = rutil.get_replication_header(newfile)
+
+    assert header.sequence == REPLICATION_CURRENT
+
+
+@pytest.mark.parametrize('end_id,max_size,actual_end', [(107, None, 107),
+                                                        (None, 1, 108),
+                                                        (105, 1, 105),
+                                                        (110, 1, 108)])
+def test_update_with_endid(test_data, runner, end_id, max_size, actual_end):
+    outfile = test_data("n1 v1 t2070-05-05T06:30:00Z")
+
+    params = [outfile]
+    if end_id is not None:
+        params.extend(('--end-id', end_id))
+    if max_size is not None:
+        params.extend(('-s', max_size))
+
+    assert (0 if end_id == actual_end else 1) == runner(*params)
+
+    ids = IDCollector()
+    osmium.apply(outfile, ids)
+
+    assert ids.relations == list(range(101, actual_end + 1))
+
+
+def test_update_with_enddate(test_data, runner, tmp_path):
+    outfile = test_data("n1 v1 t2070-05-05T06:30:00Z")
+    newfile = tmp_path / f"{uuid.uuid4()}.pbf"
+
+    assert 0 == runner('-E', '2070-05-05T09:30:00Z', '-o', newfile, outfile)
+
+    header = rutil.get_replication_header(newfile)
+
+    assert header.sequence == 105
+    assert header.timestamp == dt.datetime(year=2070, month=5, day=5, hour=9,
+                                           tzinfo=dt.timezone.utc)
+
+    ids = IDCollector()
+    osmium.apply(newfile, ids)
+
+    assert ids.relations == list(range(101, 106))


### PR DESCRIPTION
This adds a new parameter `end_id` to the diff processing functions, which allows to define the precise ID when to stop downloading diffs. This gives more fine-grained control over the number of diffs downloaded than `max_size` can do.

The tools pyosmium-get-changes and pyosmium-up-to-date get two new parameters where you can define the end date either with an ID or a date. The latter will automatically compute the appropriate ID for your convenience. Just keep in mind that date-to-ID conversions are always approximate. There is no guarantee that using `--end-date` in one run and the same date as `--start-date` in the next run will result in continuous, non-overlapping diffs. Always use the returned ID as a base for the next run.

Adds proper typing for the tool code and some tests for pyosmium-up-to-date. The tests in turn uncovered that file replacement doesn't work as expected on Windows. So fixed that.